### PR TITLE
Fix for issue #5

### DIFF
--- a/karyon-core/src/main/java/com/netflix/karyon/finder/ApplicationFinder.java
+++ b/karyon-core/src/main/java/com/netflix/karyon/finder/ApplicationFinder.java
@@ -64,6 +64,8 @@ public class ApplicationFinder {
     public Class<?> findApplication() {
 
         if (disableAppDiscovery) {
+            logger.info("Application classes discovery is turned off, not scanning for application classes. Set " +
+                        DISABLE_APPLICATION_DISCOVERY_PROP_NAME + " to false to enable this feature.");
             return null;
         }
 


### PR DESCRIPTION
The AdminResourceContainer was not getting the correct field values which were configured by governator.
Moved the logic to @PostConstruct method to honor the field values when configured by users
