### PR TITLE
karyon-examples uses simplelogger, thus simplelogger.properties (not log4j.properties)

### DIFF
--- a/karyon-examples/hello-netflix-oss/src/main/resources/log4j.properties
+++ b/karyon-examples/hello-netflix-oss/src/main/resources/log4j.properties
@@ -1,4 +1,0 @@
-log4j.rootCategory=INFO,stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d %-5p %C:%L [%t] [%M] %m%n

--- a/karyon-examples/hello-netflix-oss/src/main/resources/simplelogger.properties
+++ b/karyon-examples/hello-netflix-oss/src/main/resources/simplelogger.properties
@@ -1,0 +1,4 @@
+org.slf4j.simpleLogger.defaultLogLevel=INFO
+org.slf4j.simplelogger.showdatetime=true
+org.slf4j.simplelogger.showthreadname=true
+


### PR DESCRIPTION
Because karyon-examples uses slf4j simplelogger. so we either need to replace log4j.properties with simplelogger.properties (as this update does) or modify the build.gradle to use log4j... (I'd be happy to supply a pull with the latter, if preferred).

thanks!
-jeremy
