### PR TITLE
added masking to hide sensitive properties and environment vars in admin webapp

### DIFF
--- a/karyon-admin-web/src/main/java/com/netflix/adminresources/resources/MaskedResourceHelper.java
+++ b/karyon-admin-web/src/main/java/com/netflix/adminresources/resources/MaskedResourceHelper.java
@@ -1,0 +1,34 @@
+package com.netflix.adminresources.resources;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.netflix.config.DynamicPropertyFactory;
+
+public class MaskedResourceHelper {
+	@VisibleForTesting
+	public static final String MASKED_PROPERTY_NAMES = "netflix.platform.admin.resources.masked.property.names";
+	public static final String MASKED_PROPERTY_VALUE = "**** MASKED ****";
+	
+	private static final Splitter SPLITTER = Splitter.on(',')
+		       .trimResults()
+		       .omitEmptyStrings();
+	
+	public static Set<String> getMaskedResourceSet() {
+		String maskedResourceNames = DynamicPropertyFactory.getInstance().getStringProperty(MASKED_PROPERTY_NAMES, "").get();		
+		
+		Iterable<String> maskedResourceNamesIter = SPLITTER.split(maskedResourceNames);		
+		
+		Set<String> maskedResourceSet = new HashSet<String>();
+		for (String maskedResource : maskedResourceNamesIter) {
+			maskedResourceSet.add(maskedResource);
+		}
+		
+		// add the MASKED_PROPERTY_NAMES property, itself, for super-duper security-obscurity
+		maskedResourceSet.add(MASKED_PROPERTY_NAMES);
+		
+		return maskedResourceSet;
+	}
+}

--- a/karyon-admin-web/src/main/java/com/netflix/adminresources/resources/PropertiesResource.java
+++ b/karyon-admin-web/src/main/java/com/netflix/adminresources/resources/PropertiesResource.java
@@ -63,15 +63,21 @@ public class PropertiesResource {
         Set<String> maskedResources = MaskedResourceHelper.getMaskedResourceSet();
         
         while (keys.hasNext()) {
-            String key = keys.next();
-            // don't include any masked resources
-            if (!maskedResources.contains(key)) {
-	            Object value = config.getProperty(key);
-	            if (null != value) {
-	                allPropsAsString.put(key, value.toString());
-	            }
+            final String key = keys.next();
+
+            // mask the specified properties
+            final Object value;
+            if (maskedResources.contains(key)) {
+            	value = MaskedResourceHelper.MASKED_PROPERTY_VALUE;
+            } else {
+	            value = config.getProperty(key);
+            }
+            
+            if (null != value) {
+                allPropsAsString.put(key, value.toString());
             }
         }
+        
         GsonBuilder gsonBuilder = new GsonBuilder().serializeNulls();
         Gson gson = gsonBuilder.create();
         String propsJson = gson.toJson(new PairResponse(allPropsAsString));


### PR DESCRIPTION
https://github.com/Netflix/karyon/issues/39

new property name:  netflix.platform.admin.resources.masked.property.names=[list of property names to mask]

ideally, the admin webapp should also disallow updates to these masked properties, but there currently doesn't seem to be update functionality in the webapp, so ignoring for now.
