### PR TITLE
Initial Arquillian extension for Kayron Guice tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ allprojects {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force 'javax.servlet:javax.servlet-api:3.0.1'
+    }
+}
+
 apply from: file('gradle/convention.gradle')
 apply from: file('gradle/maven.gradle')
 apply from: file('gradle/check.gradle')
@@ -79,6 +85,20 @@ project(':karyon-extensions') {
         compile project(':karyon-core')
         compile 'javax.servlet:servlet-api:2.5'
         compile 'com.google.inject.extensions:guice-servlet:3.0'
+    }
+}
+
+project(':karyon-extensions-testsuite') {
+    dependencies {
+        compile project(':karyon-extensions')
+        compile 'javax.servlet:javax.servlet-api:3.0.1'
+        compile 'com.google.inject.extensions:guice-servlet:3.0'
+        compile 'org.jboss.arquillian.core:arquillian-core-spi:1.1.0.Final'
+        compile 'org.jboss.arquillian.container:arquillian-container-spi:1.1.0.Final'
+        compile 'org.jboss.arquillian.container:arquillian-container-test-spi:1.1.0.Final'
+        compile 'org.jboss.arquillian.container:arquillian-container-test-impl-base:1.1.0.Final'
+        compile 'org.jboss.arquillian.test:arquillian-test-spi:1.1.0.Final'
+        compile 'org.jboss.shrinkwrap:shrinkwrap-impl-base:1.1.2'
     }
 }
 

--- a/karyon-examples/hello-netflix-oss/build.gradle
+++ b/karyon-examples/hello-netflix-oss/build.gradle
@@ -26,11 +26,28 @@ war {
     webXml = file('src/main/webapp/WEB-INF/web.xml')
 }
 
+configurations {
+
+    compileOnly
+}
+
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.0'
     runtime 'org.slf4j:slf4j-simple:1.7.0'
     compile project(':karyon-extensions')
+    compile project(':karyon-extensions-testsuite')
     compile project(':karyon-admin-web')
+
+    testCompile 'org.jboss.arquillian.junit:arquillian-junit-container:1.1.0.Final'
+    testCompile 'org.jboss.shrinkwrap:shrinkwrap-impl-base:1.1.2'
+    testCompile 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:2.0.0'
+    testCompile 'org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-impl-javaee:2.0.0-alpha-3'
+    testRuntime 'org.jboss.arquillian.container:arquillian-tomcat-embedded-7:1.0.0.CR5'
+    testRuntime 'org.apache.tomcat.embed:tomcat-embed-core:7.0.42'
+    testRuntime 'org.apache.tomcat.embed:tomcat-embed-logging-juli:7.0.42'
+    testRuntime('org.apache.tomcat.embed:tomcat-embed-jasper:7.0.42') {
+        exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'
+    }
 }
 
 jettyRun.doFirst {

--- a/karyon-examples/hello-netflix-oss/src/main/webapp/WEB-INF/web.xml
+++ b/karyon-examples/hello-netflix-oss/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,9 @@
-<web-app version="2.5" xmlns="http://java.sun.com/xml/ns/javaee"
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee ">
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+	      http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
 
     <filter>
         <filter-name>guiceFilter</filter-name>

--- a/karyon-examples/hello-netflix-oss/src/test/java/com/netflix/hellonoss/core/HelloworldComponentTest.java
+++ b/karyon-examples/hello-netflix-oss/src/test/java/com/netflix/hellonoss/core/HelloworldComponentTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.hellonoss.core;
+
+import com.google.inject.Inject;
+import com.netflix.hellonoss.utils.Deployments;
+import com.netflix.kayron.server.test.RunInKaryon;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * An example test case that demonstrates injection of a simple component into a test case.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+@RunWith(Arquillian.class)
+@RunInKaryon(applicationId = "hello-netflix-oss")
+public class HelloworldComponentTest {
+
+    /**
+     * Creates the test deployment.
+     *
+     * @return the test deployment
+     */
+    @Deployment
+    public static Archive createTestArchive() {
+
+        return Deployments.createDeployment();
+    }
+
+    /**
+     * The injected component instance.
+     */
+    @Inject
+    private HelloworldComponent instance;
+
+    /**
+     * Tests the {@link HelloworldComponent#getHelloString()} method.
+     */
+    @Test
+    public void shouldRetrieveMessage() {
+
+        // then
+        assertEquals("I am a component", instance.getHelloString());
+    }
+}

--- a/karyon-examples/hello-netflix-oss/src/test/java/com/netflix/hellonoss/server/HelloworldResourceTest.java
+++ b/karyon-examples/hello-netflix-oss/src/test/java/com/netflix/hellonoss/server/HelloworldResourceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.hellonoss.server;
+
+import com.google.inject.Inject;
+import com.netflix.hellonoss.utils.Deployments;
+import com.netflix.kayron.server.test.RunInKaryon;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.ws.rs.core.Response;
+
+import static junit.framework.Assert.assertEquals;
+
+/**
+ * An example test case that demonstrates a injection of REST endpoint.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+@RunWith(Arquillian.class)
+@RunInKaryon(applicationId = "hello-netflix-oss")
+public class HelloworldResourceTest {
+
+    /**
+     * Creates the test deployment.
+     *
+     * @return the test deployment
+     */
+    @Deployment
+    public static Archive createTestArchive() {
+
+        return Deployments.createDeployment();
+    }
+
+    /**
+     * The instance of the REST service.
+     */
+    @Inject
+    private HelloworldResource instance;
+
+    /**
+     * Test the {@link HelloworldResource#hello()}.
+     */
+    @Test
+    public void shouldRetrieveHelloMessage() {
+
+        // when
+        Response response = instance.hello();
+
+        // then
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals("{\"Message\":\"Hello Netflix OSS component!\"}", response.getEntity());
+    }
+}

--- a/karyon-examples/hello-netflix-oss/src/test/java/com/netflix/hellonoss/utils/Deployments.java
+++ b/karyon-examples/hello-netflix-oss/src/test/java/com/netflix/hellonoss/utils/Deployments.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.hellonoss.utils;
+
+import com.google.inject.servlet.GuiceFilter;
+import com.netflix.hellonoss.core.HelloworldComponent;
+import com.netflix.hellonoss.server.HelloWorldBootstrap;
+import com.netflix.hellonoss.server.health.HealthCheck;
+import com.netflix.karyon.server.guice.KaryonGuiceContextListener;
+import com.netflix.kayron.server.test.KayronTestGuiceContextListener;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+import java.io.File;
+
+/**
+ * A utility class that is responsible for creating the depolyment.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+public final class Deployments {
+
+    /**
+     * Creates new instance of {@link Deployments} class.
+     * <p />
+     * The private constructor prevents from instantiation outside of this class.
+     */
+    private Deployments() {
+        // empty constructor
+    }
+
+    /**
+     * Creates the test deployment containing the whole component.
+     *
+     * @return the archive with the micro deployment of the component
+     */
+    public static Archive createDeployment() {
+
+        // adds all the dependencies needed to run the tests
+        // the jersey is used by the test application since it's exposing the JAX-RS endpoint
+        File[] libs = Maven.resolver()
+                .resolve("com.sun.jersey.contribs:jersey-guice:1.8",
+                        "org.codehaus.jackson:jackson-mapper-asl:1.9.12")
+                .withoutTransitivity()
+                .asFile();
+
+        // creates the deployment
+        return ShrinkWrap.create(WebArchive.class, "hello-netflix-oss.war")
+                .addPackage(HelloworldComponent.class.getPackage())
+                .addPackage(HelloWorldBootstrap.class.getPackage())
+                .addPackage(HealthCheck.class.getPackage())
+                .addAsResource("eureka-client.properties")
+                .addAsResource("hello-netflix-oss.properties")
+                .addAsResource("hello-netflix-oss-dev.properties")
+                .addAsResource("simplelogger.properties")
+                .setWebXML(new StringAsset(createDescriptor()))
+                .addAsLibraries(libs);
+    }
+
+    /**
+     * Creates the web descriptor for the deployment.
+     *
+     * @return the web descriptor
+     */
+    private static String createDescriptor() {
+
+        return Descriptors.create(WebAppDescriptor.class)
+                .version("3.0")
+                .createFilter()
+                .filterName("guiceFilter")
+                .filterClass(GuiceFilter.class.getName()).up()
+                .createFilterMapping()
+                .filterName("guiceFilter")
+                .urlPattern("/*").up()
+                .createListener()
+                .listenerClass(KayronTestGuiceContextListener.class.getName()).up()
+                .exportAsString();
+    }
+}

--- a/karyon-examples/hello-netflix-oss/src/test/resources/arquillian.xml
+++ b/karyon-examples/hello-netflix-oss/src/test/resources/arquillian.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+</arquillian>

--- a/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/KayronTestGuiceContextListener.java
+++ b/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/KayronTestGuiceContextListener.java
@@ -1,0 +1,48 @@
+package com.netflix.kayron.server.test;
+
+import com.google.inject.Injector;
+import com.netflix.karyon.server.guice.KaryonGuiceContextListener;
+
+/**
+ * A subclass of {@link KaryonGuiceContextListener} that simply captures the injector instance and stores it in static
+ * field.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+public class KayronTestGuiceContextListener extends KaryonGuiceContextListener {
+
+    /**
+     * The instance of the injector used by the Kayron.
+     */
+    private static Injector injector;
+
+    /**
+     * Retrieves the servlet context injector.
+     *
+     * @return the servlet context injector
+     */
+    public static synchronized Injector getServletContextInjector() {
+        return KayronTestGuiceContextListener.injector = injector;
+    }
+
+    /**
+     * Sets the servlet context injector.
+     *
+     * @param injector the servlet context injector
+     */
+    public static synchronized void setServletContextInjector(Injector injector) {
+        KayronTestGuiceContextListener.injector = injector;
+    }
+
+    /**
+     * Overrides the default implementation and additionally 'captures' the created injector instance.
+     *
+     * @return the injector
+     */
+    @Override
+    protected Injector getInjector() {
+        Injector injector = super.getInjector();
+        setServletContextInjector(injector);
+        return injector;
+    }
+}

--- a/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/RunInKaryon.java
+++ b/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/RunInKaryon.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.kayron.server.test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A annotation that can be used to indicate that the given Arquillian test is capable of injecting the Kayron
+ * configured components.
+ *
+ * <p />
+ *
+ * In order to run such test, the deployment need to properly configure the {@code KayronGuiceContextListener}.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RunInKaryon {
+
+    /**
+     * Specifies the application id that will be used to set up the Kayron environment during the deployment.
+     */
+    String applicationId() default "";
+
+    /**
+     * Allows to define the Kayron environment.
+     *
+     * <p />
+     *
+     * Defaults to {@code dev}.
+     */
+    String environment() default "dev";
+}

--- a/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/client/KayronExtensionArchiveAppender.java
+++ b/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/client/KayronExtensionArchiveAppender.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.kayron.server.test.client;
+
+import com.netflix.kayron.server.test.RunInKaryon;
+import com.netflix.kayron.server.test.server.KayronRemoteExtension;
+import com.netflix.kayron.server.test.server.KayronServerInitializer;
+import com.netflix.kayron.server.test.server.KayronTestEnricher;
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * It's responsible for packaging all the classes needed by this extension in order to run.
+ * <p />
+ * Basically it adds all the API classes and also the implementation needed to run on the server side when it will be
+ * invoked by the Arquillian runtime.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+public class KayronExtensionArchiveAppender extends CachedAuxilliaryArchiveAppender {
+
+    /**
+     * Builds the archive.
+     *
+     * @return the archive with all the needed classes.
+     */
+    @Override
+    protected Archive<?> buildArchive() {
+
+        // creates the archive
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "kayron-testsuite.jar");
+
+        // registers all the packages required by the Kayron in order to run in the container
+        addRequiredPackages(archive);
+
+        // adds the all needed classes required by the extension
+        addExtensionClasses(archive);
+
+        // returns the created archive
+        return archive;
+    }
+
+    /**
+     * Adds all the classes needed by the this extension.
+     *
+     * @param archive the archive
+     */
+    private void addExtensionClasses(JavaArchive archive) {
+
+        // adds the 'API' classes
+        archive.addClass(RunInKaryon.class);
+
+        // adds the implementation classes
+        archive.addClass(KayronRemoteExtension.class);
+        archive.addClass(KayronServerInitializer.class);
+        archive.addClass(KayronTestEnricher.class);
+
+        // registers the 'in container' extension
+        archive.addAsServiceProvider(RemoteLoadableExtension.class, KayronRemoteExtension.class);
+    }
+
+    /**
+     * Adds the minimal subset of the packages needed to run any Kayron application.
+     *
+     * @param archive the archive
+     */
+    private void addRequiredPackages(JavaArchive archive) {
+
+        archive.addPackages(true, getDependantPackagesNames());
+    }
+
+    /**
+     * Retrieves the names of the packages.
+     *
+     * @return the names of the packages
+     */
+    private String[] getDependantPackagesNames() {
+
+        return new String[]{
+                "com.netflix.governator",
+                "com.netflix.kayron",
+                "com.google.inject",
+        };
+    }
+}

--- a/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/client/KayronGuiceExtension.java
+++ b/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/client/KayronGuiceExtension.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.kayron.server.test.client;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * An entry point of the extension that boostraps all the needed classes.
+ * <p />
+ * The extension is being registered through LoadableExtension file located in the META-INF/services directory.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+public class KayronGuiceExtension implements LoadableExtension {
+
+    /**
+     * Registers the extension.
+     *
+     * @param builder the extension builder
+     */
+    @Override
+    public void register(ExtensionBuilder builder) {
+
+        // registers the extension archive appender
+        builder.service(AuxiliaryArchiveAppender.class, KayronExtensionArchiveAppender.class);
+    }
+}

--- a/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/server/KayronRemoteExtension.java
+++ b/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/server/KayronRemoteExtension.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.kayron.server.test.server;
+
+import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
+
+/**
+ * Registers the remote extension in the executing container.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+public class KayronRemoteExtension implements RemoteLoadableExtension {
+
+    /**
+     * Registers the extension.
+     *
+     * @param builder the extension builder
+     */
+    @Override
+    public void register(ExtensionBuilder builder) {
+
+        // registers the test enricher
+        builder.service(TestEnricher.class, KayronTestEnricher.class)
+                .observer(KayronServerInitializer.class);
+    }
+}

--- a/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/server/KayronServerInitializer.java
+++ b/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/server/KayronServerInitializer.java
@@ -1,0 +1,34 @@
+package com.netflix.kayron.server.test.server;
+
+import com.netflix.kayron.server.test.RunInKaryon;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.Before;
+
+/**
+ * A test initializer that sets up the Kayron environment in the server.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+public class KayronServerInitializer {
+
+    /**
+     * Handles the before test event.
+     *
+     * @param event the before test event
+     */
+    public void beforeTest(@Observes Before event) {
+
+        RunInKaryon annotation = event.getTestClass().getAnnotation(RunInKaryon.class);
+
+        if (annotation != null) {
+
+            if (!annotation.applicationId().isEmpty()) {
+                System.setProperty("archaius.deployment.applicationId", annotation.applicationId());
+            }
+
+            if (!annotation.environment().isEmpty()) {
+                System.setProperty("archaius.deployment.environment", annotation.environment());
+            }
+        }
+    }
+}

--- a/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/server/KayronTestEnricher.java
+++ b/karyon-extensions-testsuite/src/main/java/com/netflix/kayron/server/test/server/KayronTestEnricher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+package com.netflix.kayron.server.test.server;
+
+import com.google.inject.Injector;
+import com.netflix.karyon.server.guice.KaryonGuiceContextListener;
+import com.netflix.kayron.server.test.KayronTestGuiceContextListener;
+import com.netflix.kayron.server.test.RunInKaryon;
+import org.jboss.arquillian.test.spi.TestEnricher;
+
+import java.lang.reflect.Method;
+
+/**
+ * The Arquillian test enricher, that is able to inject the Kayron configured components.
+ * <p />
+ * Basically this enricher injects all the Guice configured injection points.
+ *
+ * @author Jakub Narloch (jmnarloch@gmail.com)
+ */
+public class KayronTestEnricher implements TestEnricher {
+
+    /**
+     * Enriches the test instance, by injecting all Kayron configured dependencies.
+     *
+     * @param testCase the test instance
+     */
+    @Override
+    public void enrich(Object testCase) {
+
+        // verifies whether the test case should be enriched
+        if (testCase.getClass().isAnnotationPresent(RunInKaryon.class)) {
+
+            // tries to enquire the injector
+            Injector injector = getServletContextInjector();
+
+            if (injector == null) {
+
+                throw new RuntimeException("The Injector instance could not be enquired."
+                        + " Have you configured the KaryonGuiceContextListener properly?");
+            }
+
+            injector.injectMembers(testCase);
+        }
+    }
+
+    /**
+     * Resolves the test method parameters.
+     * <p />
+     * The implementation does nothing, because the underlying Guice injector is not capable of injecting the method
+     * parameters.
+     *
+     * @param method the test method
+     *
+     * @return an empty array
+     */
+    @Override
+    public Object[] resolve(Method method) {
+        return new Object[0];
+    }
+
+    /**
+     * Retrieves the Kayron configured injector from the servlet context.
+     *
+     * @return the injector
+     */
+    private Injector getServletContextInjector() {
+
+        return KayronTestGuiceContextListener.getServletContextInjector();
+    }
+}

--- a/karyon-extensions-testsuite/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/karyon-extensions-testsuite/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+com.netflix.kayron.server.test.client.KayronGuiceExtension

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,4 +15,4 @@
  */
 
 rootProject.name='karyon'
-include 'karyon-spi','karyon-eureka','karyon-core','karyon-extensions', 'karyon-admin', 'karyon-admin-web', 'karyon-examples:hello-netflix-oss'
+include 'karyon-spi','karyon-eureka','karyon-core','karyon-extensions','karyon-extensions-testsuite','karyon-admin', 'karyon-admin-web', 'karyon-examples:hello-netflix-oss'


### PR DESCRIPTION
This is an initial version of an extension that is capable of injecting Kayron auto scanned components into the test case. The only requirement is to annotate the test with @KayronAwareTest (we can change that name to something different :)).

Features:
- Injecting the Guice dependencies into a test case in the remote running container.
- Packaging the minimal sub set of Kayron classes/dependencies in order to run in the container.

How this works:
- Basicly the two important points of the implementation are the KayronExtensionArchiveAppender, since we are deploying the code into the container, we need to package all the extension classes into a micro deployment. So this class does all the dirty work and creates the archive of the extension implementation classes. The second one is the KayronTestEnricher, which simply enquires the injector and injects all the dependencies on the test.

TODO list:
- Some additional unit tests of the extension itself, at the moment I have left that untill we discuss the ext. shape in general.
- How to pass the Injector? At the moment I have added a static field directly to the KaryonGuiceContextListener.
- Decide what should be packaged by the default.
- How to identify the Kayron test? For that purpose I introduced the annotation (@KayronAwareTest ), but we can use different approach.
- Where to put the code? I have added new sub module, but preferable I would split the kayron-extension and put there additional sub modules with one containing the test extension. Although, this brakes the existing artifact naming and I'm not aware how this affect other systems.
