### PR TITLE
This fixes #67 by replacing the call to Guava's Closeables.closeQuitely(...

### DIFF
--- a/karyon-core/src/main/java/com/netflix/karyon/server/KaryonServer.java
+++ b/karyon-core/src/main/java/com/netflix/karyon/server/KaryonServer.java
@@ -214,7 +214,7 @@ public class KaryonServer implements Closeable {
         if (null != initializer) {
             initializer.close();
         }
-        Closeables.closeQuietly(lifecycleManager);
+        Closeables.close(lifecycleManager, true);
         logger.info("Successfully shut down karyon.");
     }
 


### PR DESCRIPTION
...) in the KaryonServer's shutdown with its new version
