### PR TITLE
Fixes #63

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     governatorVersion="1.2.12"
     archaiusVersion="0.6.0"
     pytheasVersion="1.11"
-    eurekaVersion="1.1.132"
+    eurekaVersion="1.1.138"
 }
 
 buildscript {

--- a/karyon-eureka/src/main/java/com/netflix/karyon/server/eureka/DefaultEurekaKaryonStatusBridge.java
+++ b/karyon-eureka/src/main/java/com/netflix/karyon/server/eureka/DefaultEurekaKaryonStatusBridge.java
@@ -1,0 +1,20 @@
+package com.netflix.karyon.server.eureka;
+
+import com.netflix.appinfo.InstanceInfo;
+
+/**
+ * @author Nitesh Kant
+ */
+public class DefaultEurekaKaryonStatusBridge implements EurekaKaryonStatusBridge {
+
+    @Override
+    public InstanceInfo.InstanceStatus interpretKaryonStatus(int karyonStatus) {
+        if(karyonStatus == 204) {
+            return InstanceInfo.InstanceStatus.STARTING;
+        } else if (karyonStatus >= 200 && karyonStatus < 300) {
+            return InstanceInfo.InstanceStatus.UP;
+        }
+
+        return InstanceInfo.InstanceStatus.DOWN;
+    }
+}

--- a/karyon-eureka/src/main/java/com/netflix/karyon/server/eureka/EurekaHealthCheckCallback.java
+++ b/karyon-eureka/src/main/java/com/netflix/karyon/server/eureka/EurekaHealthCheckCallback.java
@@ -28,7 +28,9 @@ import java.util.concurrent.TimeoutException;
 
 /**
  * @author Nitesh Kant
+ * @deprecated Use {@link EurekaHealthCheckHandler} instead.
  */
+@Deprecated
 public class EurekaHealthCheckCallback implements HealthCheckCallback {
 
     protected static final Logger logger = LoggerFactory.getLogger(EurekaHandler.class);

--- a/karyon-eureka/src/main/java/com/netflix/karyon/server/eureka/EurekaHealthCheckHandler.java
+++ b/karyon-eureka/src/main/java/com/netflix/karyon/server/eureka/EurekaHealthCheckHandler.java
@@ -1,0 +1,28 @@
+package com.netflix.karyon.server.eureka;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.karyon.spi.HealthCheckHandler;
+
+import javax.inject.Inject;
+
+/**
+ * @author Nitesh Kant
+ */
+public class EurekaHealthCheckHandler implements com.netflix.appinfo.HealthCheckHandler {
+
+    private final HealthCheckHandler healthCheckHandler;
+    private final EurekaKaryonStatusBridge eurekaKaryonStatusBridge;
+
+    @Inject
+    public EurekaHealthCheckHandler(HealthCheckHandler healthCheckHandler,
+                                    EurekaKaryonStatusBridge eurekaKaryonStatusBridge) {
+        this.healthCheckHandler = healthCheckHandler;
+        this.eurekaKaryonStatusBridge = eurekaKaryonStatusBridge;
+    }
+
+    @Override
+    public InstanceInfo.InstanceStatus getStatus(InstanceInfo.InstanceStatus currentStatus) {
+        int healthStatus = healthCheckHandler.getStatus();
+        return eurekaKaryonStatusBridge.interpretKaryonStatus(healthStatus);
+    }
+}

--- a/karyon-eureka/src/main/java/com/netflix/karyon/server/eureka/EurekaKaryonStatusBridge.java
+++ b/karyon-eureka/src/main/java/com/netflix/karyon/server/eureka/EurekaKaryonStatusBridge.java
@@ -1,0 +1,13 @@
+package com.netflix.karyon.server.eureka;
+
+import com.google.inject.ImplementedBy;
+import com.netflix.appinfo.InstanceInfo;
+
+/**
+ * @author Nitesh Kant
+ */
+@ImplementedBy(DefaultEurekaKaryonStatusBridge.class)
+public interface EurekaKaryonStatusBridge {
+
+    InstanceInfo.InstanceStatus interpretKaryonStatus(int karyonStatus);
+}

--- a/karyon-examples/hello-netflix-oss/src/main/java/com/netflix/hellonoss/core/HelloworldComponent.java
+++ b/karyon-examples/hello-netflix-oss/src/main/java/com/netflix/hellonoss/core/HelloworldComponent.java
@@ -16,6 +16,7 @@
 
 package com.netflix.hellonoss.core;
 
+import com.google.inject.Singleton;
 import com.netflix.karyon.spi.Component;
 
 import javax.annotation.PostConstruct;
@@ -24,9 +25,11 @@ import javax.annotation.PostConstruct;
  * @author Nitesh Kant (nkant@netflix.com)
  */
 @Component
+@Singleton
 public class HelloworldComponent {
 
     private String helloString = "I am a component";
+    private boolean isReady;
 
     @PostConstruct
     public void initialize() {
@@ -35,5 +38,13 @@ public class HelloworldComponent {
 
     public String getHelloString() {
         return helloString;
+    }
+
+    public boolean isReady() { // To simulate realworld healthcheck, by checking if the component is ready to serve traffic.
+        return isReady;
+    }
+
+    public void setReady(boolean isReady) { // Providing a hook for externally driven availability. (testing purpose)
+        this.isReady = isReady;
     }
 }

--- a/karyon-examples/hello-netflix-oss/src/main/java/com/netflix/hellonoss/server/HelloworldResource.java
+++ b/karyon-examples/hello-netflix-oss/src/main/java/com/netflix/hellonoss/server/HelloworldResource.java
@@ -82,5 +82,19 @@ public class HelloworldResource {
         }
     }
 
+    @Path("start")
+    @GET
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response start() {
+        component.setReady(true);
+        return Response.noContent().build();
+    }
 
+    @Path("stop")
+    @GET
+    @Produces({MediaType.APPLICATION_JSON})
+    public Response stop() {
+        component.setReady(false);
+        return Response.noContent().build();
+    }
 }

--- a/karyon-examples/hello-netflix-oss/src/main/java/com/netflix/hellonoss/server/health/HealthCheck.java
+++ b/karyon-examples/hello-netflix-oss/src/main/java/com/netflix/hellonoss/server/health/HealthCheck.java
@@ -46,7 +46,6 @@ public class HealthCheck implements HealthCheckHandler {
     public int getStatus() {
         // TODO: Health check logic.
         logger.info("Health check invoked.");
-        logger.info("Message from component: " + component.getHelloString());
-        return 200;
+        return component.isReady() ? 200 : 204;
     }
 }

--- a/karyon-examples/hello-netflix-oss/src/main/java/com/netflix/hellonoss/server/health/HealthcheckResource.java
+++ b/karyon-examples/hello-netflix-oss/src/main/java/com/netflix/hellonoss/server/health/HealthcheckResource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 Netflix, Inc.
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+package com.netflix.hellonoss.server.health;
+
+import com.google.inject.Inject;
+import com.netflix.karyon.server.eureka.HealthCheckInvocationStrategy;
+import com.sun.jersey.spi.resource.Singleton;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.util.concurrent.TimeoutException;
+
+@Path("/healthcheck")
+@Singleton
+public class HealthcheckResource {
+
+    @Inject(optional = true)
+    private HealthCheckInvocationStrategy invocationStrategy;
+
+    @GET
+    public Response doHealthCheck() {
+        if (null != invocationStrategy) {
+            try {
+                int status = invocationStrategy.invokeCheck();
+                return Response.status(status).build();
+            } catch (TimeoutException e) {
+                return Response.status(Response.Status.SERVICE_UNAVAILABLE).build();
+            }
+        } else {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+}

--- a/karyon-examples/hello-netflix-oss/src/main/resources/hello-netflix-oss.properties
+++ b/karyon-examples/hello-netflix-oss/src/main/resources/hello-netflix-oss.properties
@@ -10,3 +10,6 @@ com.netflix.karyon.health.check.handler.classname=com.netflix.hellonoss.server.h
 
 # Comment this property if you need eureka integration and populate eureka-client.properties with your environment details.
 com.netflix.karyon.eureka.disable=true
+
+# uses the more flexible healthcheck handler.
+com.netflix.karyon.eureka.use.healthcheck.handler=true

--- a/karyon-spi/src/main/java/com/netflix/karyon/spi/PropertyNames.java
+++ b/karyon-spi/src/main/java/com/netflix/karyon/spi/PropertyNames.java
@@ -45,6 +45,11 @@ public class PropertyNames {
     public static final String EUREKA_PROPERTIES_NAME_PREFIX_PROP_NAME = KARYON_PROPERTIES_PREFIX + "eureka.properties.prefix";
 
     /**
+     * Prefix for all eureka related properties. Default is "eureka"
+     */
+    public static final String USE_EUREKA_HEALTHCHECK_HANDLER = KARYON_PROPERTIES_PREFIX + "eureka.use.healthcheck.handler";
+
+    /**
      * Prefix for all eureka related properties. Default to the value set in {@link PropertyNames#EUREKA_PROPERTIES_NAME_PREFIX_PROP_NAME}
      */
     public static final String EUREKA_CLIENT_PROPERTIES_NAME_PREFIX_PROP_NAME = KARYON_PROPERTIES_PREFIX + "eureka.client.properties.prefix";


### PR DESCRIPTION
Integrated with new eureka functionality of providing a HealthcheckHandler that provides detailed eureka status as opposed to a binary value.

Since, we need to be backward compatible with existing Healthcheck implementation, this change deprecates the older way and adds a new way of healthcheck. The karyon healthcheck abstraction does not change.

The new functionality can be enabled by using the property "com.netflix.karyon.eureka.use.healthcheck.handler=true"

Also updated the example to demonstrate this behavior.
