### PR TITLE
Modifying gradle org to com.netflix.karyon2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
     sourceCompatibility = JavaVersion.VERSION_1_7
     targetCompatibility = JavaVersion.VERSION_1_7
 
-    group = "netflix.karyon"
+    group = "com.netflix.karyon2"
 
     apply plugin: 'java'
     apply plugin: 'eclipse'


### PR DESCRIPTION
We can not publish to maven if the org does not start with com.netflix
