### PR TITLE
fix javadoc errors which were stopping build

### DIFF
--- a/karyon-core/src/main/java/netflix/karyon/health/HealthCheckInvocationStrategy.java
+++ b/karyon-core/src/main/java/netflix/karyon/health/HealthCheckInvocationStrategy.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * A strategy to make application specific healthchecks. Since, the application health checks can be poorly implemented
  * and hence take a long time to complete, in some cases, it is wise to have an SLA around the health check response
- * times. <p></p>
+ * times.
  * There is a 1:1 mapping between a strategy instance and a {@link HealthCheckHandler} instance and hence it is assumed
  * that the strategy already knows about the handler instance.
  *

--- a/karyon-core/src/main/java/netflix/karyon/transport/http/RegexUriConstraintKey.java
+++ b/karyon-core/src/main/java/netflix/karyon/transport/http/RegexUriConstraintKey.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 /**
  * Provides constraint implementation for {@link netflix.karyon.transport.interceptor.InterceptorKey} for matching URI paths as regular expressions as
- * supported by {@link java.util.regex.Pattern}. <p></p>
+ * supported by {@link java.util.regex.Pattern}.
  * The request URI path is as retrieved using: {@link HttpKeyEvaluationContext#getRequestUriPath(HttpServerRequest)}
  *
  * @author Nitesh Kant

--- a/karyon-core/src/main/java/netflix/karyon/transport/http/ServletStyleUriConstraintKey.java
+++ b/karyon-core/src/main/java/netflix/karyon/transport/http/ServletStyleUriConstraintKey.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provides constraint implementation for {@link netflix.karyon.transport.interceptor.InterceptorKey} similar to java servlet specifications. <p></p>
+ * Provides constraint implementation for {@link netflix.karyon.transport.interceptor.InterceptorKey} similar to java servlet specifications. 
  * The following types of constraints are supported:
  * <ul>
  <li>Exact uri mapping: Give the exact string that should match the URI path of the incoming request.
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  </ul>
  *
  * In any of the pattersn above the leading slash in the constraint is optional, i.e., "/myresource/foo" is equivalent to
- * "myresource/foo". <p></p>
+ * "myresource/foo".
  *
  * As compared to servlets/web applications there are no context paths of an application so the URI path has to be
  * absolute. <br>

--- a/karyon-core/src/main/java/netflix/karyon/transport/http/ServletStyleUriConstraintKey.java
+++ b/karyon-core/src/main/java/netflix/karyon/transport/http/ServletStyleUriConstraintKey.java
@@ -5,7 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provides constraint implementation for {@link netflix.karyon.transport.interceptor.InterceptorKey} similar to java servlet specifications. 
+ * Provides constraint implementation for {@link netflix.karyon.transport.interceptor.InterceptorKey} similar to java servlet specifications.
  * The following types of constraints are supported:
  * <ul>
  <li>Exact uri mapping: Give the exact string that should match the URI path of the incoming request.

--- a/karyon-core/src/main/java/netflix/karyon/transport/http/SimpleUriRouter.java
+++ b/karyon-core/src/main/java/netflix/karyon/transport/http/SimpleUriRouter.java
@@ -42,7 +42,7 @@ public class SimpleUriRouter<I, O> implements RequestHandler<I, O> {
     }
 
     /**
-     * Add a new URI -> Handler route to this router.
+     * Add a new URI -&lt; Handler route to this router.
      * @param uri URI to match.
      * @param handler Request handler.
      * @return The updated router.
@@ -53,7 +53,7 @@ public class SimpleUriRouter<I, O> implements RequestHandler<I, O> {
     }
 
     /**
-     * Add a new URI regex -> Handler route to this router.
+     * Add a new URI regex -&lt; Handler route to this router.
      * @param uriRegEx URI regex to match
      * @param handler Request handler.
      * @return The updated router.

--- a/karyon-core/src/main/java/netflix/karyon/transport/interceptor/KeyEvaluationContext.java
+++ b/karyon-core/src/main/java/netflix/karyon/transport/interceptor/KeyEvaluationContext.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A context to store results of costly operations during evaluation of filter keys, eg: request URI parsing. <p></p>
+ * A context to store results of costly operations during evaluation of filter keys, eg: request URI parsing.
  * <b>This context is not thread-safe.</b>
  */
 public class KeyEvaluationContext {


### PR DESCRIPTION
Hi.

The greater than signs in the java comments were causing the gradle build to fail.
I adjusted them, and got rid of a couple of other complaints the javadoc stage was complaining about. 
(empty <p></p> spots mainly).
