### PR TITLE
Add governator dependency conflict resolution

### DIFF
--- a/karyon-examples/build.gradle
+++ b/karyon-examples/build.gradle
@@ -17,6 +17,17 @@ ext.githubProjectName = rootProject.name // Change if github project name is not
 
 apply plugin: 'application'
 
+configurations.all {
+    resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            // examples depend on an older version of governator
+            if (details.requested.group == 'com.netflix.governator') {
+                details.useVersion'1.2.20'
+            }
+        }
+    }
+}
+
 buildscript {
     repositories { mavenCentral() }
     apply from: file('../gradle/buildscript.gradle'), to: buildscript


### PR DESCRIPTION
The examples require an earlier version of governator, but karyon-admin
pulls in version 1.3 which causes a conflict resulting in a method not
found error on LifecycleInjector.bootstrap()