### PR TITLE
update to pytheas-1.22

### DIFF
--- a/karyon-admin/build.gradle
+++ b/karyon-admin/build.gradle
@@ -32,7 +32,7 @@ dependencies {
         compile 'com.sun.jersey:jersey-servlet:1.17.1'
         compile 'com.sun.jersey:jersey-server:1.17.1'
         compile 'com.google.inject.extensions:guice-servlet:3.0'
-        compile 'com.netflix.pytheas:pytheas-core:1.20'
+        compile 'com.netflix.pytheas:pytheas-core:1.22'
         compile 'com.sun.jersey:jersey-core:1.17.1'
         runtime 'org.codehaus.jackson:jackson-mapper-asl:1.9.11'
     }


### PR DESCRIPTION
Cleans up a transitive dependency pulling in
karyon-core-1.x.
