### PR TITLE
Bump governor, rxnetty and guava versions.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,6 @@
 #      limitations under the License.
 #
 version=2.2.00-ALPHA4
-rxnetty_version=0.3.17
-jersey_version=1.17.1
+rxnetty_version=0.4.4
+jersey_version=1.18.1
+governator_version=1.3.3

--- a/karyon-admin-web/src/main/java/netflix/adminresources/resources/KaryonWebAdminModule.java
+++ b/karyon-admin-web/src/main/java/netflix/adminresources/resources/KaryonWebAdminModule.java
@@ -1,8 +1,8 @@
 package netflix.adminresources.resources;
 
-import com.netflix.governator.guice.LifecycleInjectorBuilder;
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+import com.netflix.governator.guice.BootstrapModule;
 import netflix.adminresources.KaryonAdminModule;
+import netflix.karyon.Karyon;
 
 public class KaryonWebAdminModule extends KaryonAdminModule {
 
@@ -12,12 +12,7 @@ public class KaryonWebAdminModule extends KaryonAdminModule {
         bind(WebAdminComponent.class).asEagerSingleton();
     }
 
-    public static LifecycleInjectorBuilderSuite asSuite() {
-        return new LifecycleInjectorBuilderSuite() {
-            @Override
-            public void configure(LifecycleInjectorBuilder builder) {
-                builder.withAdditionalModules(new KaryonWebAdminModule());
-            }
-        };
+    public static BootstrapModule asBootstrapModule() {
+        return Karyon.toBootstrapModule(KaryonWebAdminModule.class);
     }
 }

--- a/karyon-admin/build.gradle
+++ b/karyon-admin/build.gradle
@@ -29,11 +29,11 @@ dependencies {
         compile 'org.eclipse.jetty:jetty-server:7.6.7.v20120910'
         compile 'org.eclipse.jetty:jetty-servlet:7.6.7.v20120910'
         compile 'com.sun.jersey.contribs:jersey-guice:1.17.1'
-        compile 'com.sun.jersey:jersey-servlet:1.17.1'
-        compile 'com.sun.jersey:jersey-server:1.17.1'
+        compile "com.sun.jersey:jersey-servlet:${jersey_version}"
+        compile "com.sun.jersey:jersey-server:${jersey_version}"
         compile 'com.google.inject.extensions:guice-servlet:3.0'
         compile 'com.netflix.pytheas:pytheas-core:1.22'
-        compile 'com.sun.jersey:jersey-core:1.17.1'
+        compile "com.sun.jersey:jersey-core:${jersey_version}"
         runtime 'org.codehaus.jackson:jackson-mapper-asl:1.9.11'
     }
 }

--- a/karyon-admin/src/main/java/netflix/admin/AdminExplorerManager.java
+++ b/karyon-admin/src/main/java/netflix/admin/AdminExplorerManager.java
@@ -72,7 +72,7 @@ public class AdminExplorerManager implements ExplorerManager {
 
     @Override
     public Collection<Explorer> getExplorers() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/karyon-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -127,6 +127,7 @@ public class AdminResourcesContainer {
                         bind(AdminResourcesFilter.class).asEagerSingleton();
                     }
                 })
+                .build()
                 .createInjector();
         injector.getInstance(LifecycleManager.class).start();
 

--- a/karyon-archaius/build.gradle
+++ b/karyon-archaius/build.gradle
@@ -20,9 +20,8 @@ tasks.withType(Javadoc).each {
 }
 
 dependencies {
-    dependencies {
-        compile project(':karyon-governator')
-    }
+    compile project(':karyon-governator')
+    compile 'com.netflix.archaius:archaius-core:0.6.3'
 }
 
 eclipse {

--- a/karyon-archaius/src/main/java/netflix/karyon/archaius/ArchaiusBootstrap.java
+++ b/karyon-archaius/src/main/java/netflix/karyon/archaius/ArchaiusBootstrap.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-@Bootstrap(ArchaiusSuite.class)
+@Bootstrap(bootstrap = ArchaiusBootstrapModule.class)
 public @interface ArchaiusBootstrap {
 
     Class<? extends PropertiesLoader> loader() default DefaultPropertiesLoader.class;

--- a/karyon-archaius/src/main/java/netflix/karyon/archaius/ArchaiusBootstrapModule.java
+++ b/karyon-archaius/src/main/java/netflix/karyon/archaius/ArchaiusBootstrapModule.java
@@ -4,8 +4,6 @@ import com.netflix.governator.configuration.ArchaiusConfigurationProvider;
 import com.netflix.governator.configuration.ConfigurationOwnershipPolicies;
 import com.netflix.governator.guice.BootstrapBinder;
 import com.netflix.governator.guice.BootstrapModule;
-import com.netflix.governator.guice.LifecycleInjectorBuilder;
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
 
 import javax.inject.Inject;
 
@@ -14,48 +12,42 @@ import javax.inject.Inject;
  *
  * @author Nitesh Kant
  */
-public class ArchaiusSuite implements LifecycleInjectorBuilderSuite {
+public class ArchaiusBootstrapModule implements BootstrapModule {
 
     private final Class<? extends PropertiesLoader> propertiesLoaderClass;
     private final PropertiesLoader propertiesLoader;
 
-    public ArchaiusSuite(String appName) {
+    public ArchaiusBootstrapModule(String appName) {
         this(new DefaultPropertiesLoader(appName));
     }
 
-    public ArchaiusSuite(PropertiesLoader propertiesLoader) {
+    public ArchaiusBootstrapModule(PropertiesLoader propertiesLoader) {
         this.propertiesLoader = propertiesLoader;
         this.propertiesLoaderClass = null;
     }
 
-    public ArchaiusSuite(Class<PropertiesLoader> propertiesLoader) {
+    public ArchaiusBootstrapModule(Class<PropertiesLoader> propertiesLoader) {
         this.propertiesLoaderClass = propertiesLoader;
         this.propertiesLoader = null;
     }
 
     @Inject
-    ArchaiusSuite(ArchaiusBootstrap archaiusBootstrap) {
+    ArchaiusBootstrapModule(ArchaiusBootstrap archaiusBootstrap) {
         propertiesLoaderClass = archaiusBootstrap.loader();
         propertiesLoader = null;
     }
 
     @Override
-    public void configure(LifecycleInjectorBuilder builder) {
-        builder.withAdditionalBootstrapModules(new BootstrapModule() {
-
-            @Override
-            public void configure(BootstrapBinder bootstrapBinder) {
-                if (null != propertiesLoaderClass) {
-                    bootstrapBinder.bind(PropertiesLoader.class).to(propertiesLoaderClass).asEagerSingleton();
-                } else {
-                    bootstrapBinder.bind(PropertiesLoader.class).toInstance(propertiesLoader);
-                }
-                bootstrapBinder.bind(PropertiesInitializer.class).asEagerSingleton();
-                ArchaiusConfigurationProvider.Builder builder = ArchaiusConfigurationProvider.builder();
-                builder.withOwnershipPolicy(ConfigurationOwnershipPolicies.ownsAll());
-                bootstrapBinder.bindConfigurationProvider().toInstance(builder.build());
-            }
-        });
+    public void configure(BootstrapBinder bootstrapBinder) {
+        if (null != propertiesLoaderClass) {
+            bootstrapBinder.bind(PropertiesLoader.class).to(propertiesLoaderClass).asEagerSingleton();
+        } else {
+            bootstrapBinder.bind(PropertiesLoader.class).toInstance(propertiesLoader);
+        }
+        bootstrapBinder.bind(PropertiesInitializer.class).asEagerSingleton();
+        ArchaiusConfigurationProvider.Builder builder = ArchaiusConfigurationProvider.builder();
+        builder.withOwnershipPolicy(ConfigurationOwnershipPolicies.ownsAll());
+        bootstrapBinder.bindConfigurationProvider().toInstance(builder.build());
     }
 
     /**

--- a/karyon-core/build.gradle
+++ b/karyon-core/build.gradle
@@ -20,9 +20,7 @@ tasks.withType(Javadoc).each {
 }
 
 dependencies {
-    dependencies {
-        compile "com.netflix.rxnetty:rx-netty-contexts:${rxnetty_version}"
-    }
+    compile "io.reactivex:rxnetty-contexts:${rxnetty_version}"
 }
 
 eclipse {

--- a/karyon-eureka/build.gradle
+++ b/karyon-eureka/build.gradle
@@ -22,7 +22,7 @@ tasks.withType(Javadoc).each {
 dependencies {
     dependencies {
         compile project(':karyon-governator')
-        compile 'com.netflix.eureka:eureka-client:1.1.135'
+        compile 'com.netflix.eureka:eureka-client:1.1.146'
     }
 }
 

--- a/karyon-eureka/src/main/java/netflix/karyon/eureka/KaryonEurekaModule.java
+++ b/karyon-eureka/src/main/java/netflix/karyon/eureka/KaryonEurekaModule.java
@@ -9,10 +9,13 @@ import com.netflix.discovery.DiscoveryClient;
 import com.netflix.discovery.EurekaClientConfig;
 import com.netflix.discovery.EurekaNamespace;
 import com.netflix.discovery.providers.DefaultEurekaClientConfigProvider;
-import com.netflix.governator.guice.LifecycleInjectorBuilder;
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+import com.netflix.governator.guice.BootstrapModule;
+import netflix.karyon.Karyon;
 
 /**
+ * Initialize Eureka, by binding the &quot;eureka.&quot; namespace and adding providers for EurekaClientConfig
+ * and EurekaInstanceConfig.
+ *
  * @author Nitesh Kant
  */
 public class KaryonEurekaModule extends AbstractModule {
@@ -44,12 +47,8 @@ public class KaryonEurekaModule extends AbstractModule {
         return bind(String.class).annotatedWith(EurekaNamespace.class);
     }
 
-    public static LifecycleInjectorBuilderSuite asSuite() {
-        return new LifecycleInjectorBuilderSuite() {
-            @Override
-            public void configure(LifecycleInjectorBuilder builder) {
-                builder.withAdditionalModules(new KaryonEurekaModule());
-            }
-        };
+    public static BootstrapModule asBootstrapModule() {
+        return Karyon.toBootstrapModule(KaryonEurekaModule.class);
     }
+
 }

--- a/karyon-examples/src/main/java/netflix/karyon/examples/hellonoss/server/rxnetty/MyApplicationRunner.java
+++ b/karyon-examples/src/main/java/netflix/karyon/examples/hellonoss/server/rxnetty/MyApplicationRunner.java
@@ -2,9 +2,9 @@ package netflix.karyon.examples.hellonoss.server.rxnetty;
 
 import netflix.adminresources.resources.KaryonWebAdminModule;
 import netflix.karyon.Karyon;
-import netflix.karyon.KaryonBootstrapSuite;
+import netflix.karyon.KaryonBootstrapModule;
 import netflix.karyon.ShutdownModule;
-import netflix.karyon.archaius.ArchaiusSuite;
+import netflix.karyon.archaius.ArchaiusBootstrapModule;
 import netflix.karyon.examples.hellonoss.common.health.HealthCheck;
 import netflix.karyon.servo.KaryonServoModule;
 import netflix.karyon.transport.http.health.HealthCheckEndpoint;
@@ -19,12 +19,12 @@ public class MyApplicationRunner {
         Karyon.forRequestHandler(8888,
                                  new RxNettyHandler("/healthcheck",
                                                     new HealthCheckEndpoint(healthCheckHandler)),
-                                 new KaryonBootstrapSuite(healthCheckHandler),
-                                 new ArchaiusSuite("hello-netflix-oss"),
-                                 // KaryonEurekaModule.asSuite(), /* Uncomment if you need eureka */
-                                 KaryonWebAdminModule.asSuite(),
-                                 ShutdownModule.asSuite(),
-                                 KaryonServoModule.asSuite())
+                                 new KaryonBootstrapModule(healthCheckHandler),
+                                 new ArchaiusBootstrapModule("hello-netflix-oss"),
+                                 // KaryonEurekaModule.asBootstrapModule(), /* Uncomment if you need eureka */
+                                 KaryonWebAdminModule.asBootstrapModule(),
+                                 ShutdownModule.asBootstrapModule(),
+                                 KaryonServoModule.asBootstrapModule())
               .startAndWaitTillShutdown();
     }
 }

--- a/karyon-examples/src/main/java/netflix/karyon/examples/hellonoss/server/simple/module/SimpleRunner.java
+++ b/karyon-examples/src/main/java/netflix/karyon/examples/hellonoss/server/simple/module/SimpleRunner.java
@@ -2,9 +2,9 @@ package netflix.karyon.examples.hellonoss.server.simple.module;
 
 import netflix.adminresources.resources.KaryonWebAdminModule;
 import netflix.karyon.Karyon;
-import netflix.karyon.KaryonBootstrapSuite;
+import netflix.karyon.KaryonBootstrapModule;
 import netflix.karyon.ShutdownModule;
-import netflix.karyon.archaius.ArchaiusSuite;
+import netflix.karyon.archaius.ArchaiusBootstrapModule;
 import netflix.karyon.servo.KaryonServoModule;
 
 /**
@@ -17,12 +17,12 @@ public class SimpleRunner {
         Karyon.forRequestHandler(8888,
                                  // new SimpleRouter(), /* Use this instead of RouterWithInterceptors below if interceptors are not required */
                                  new RouterWithInterceptors(),
-                                 new KaryonBootstrapSuite(),
-                                 new ArchaiusSuite("hello-netflix-oss"),
-                                 // KaryonEurekaModule.asSuite(), /* Uncomment if you need eureka */
-                                 KaryonWebAdminModule.asSuite(),
-                                 ShutdownModule.asSuite(),
-                                 KaryonServoModule.asSuite())
+                                 new KaryonBootstrapModule(),
+                                 new ArchaiusBootstrapModule("hello-netflix-oss"),
+                                 // KaryonEurekaModule.asBootstrapModule(), /* Uncomment if you need eureka */
+                                 KaryonWebAdminModule.asBootstrapModule(),
+                                 ShutdownModule.asBootstrapModule(),
+                                 KaryonServoModule.asBootstrapModule())
               .startAndWaitTillShutdown();
     }
 }

--- a/karyon-examples/src/main/java/netflix/karyon/examples/websockets/WebSocketEchoServer.java
+++ b/karyon-examples/src/main/java/netflix/karyon/examples/websockets/WebSocketEchoServer.java
@@ -8,9 +8,9 @@ import io.reactivex.netty.channel.ObservableConnection;
 import io.reactivex.netty.server.RxServer;
 import netflix.adminresources.resources.KaryonWebAdminModule;
 import netflix.karyon.Karyon;
-import netflix.karyon.KaryonBootstrapSuite;
+import netflix.karyon.KaryonBootstrapModule;
 import netflix.karyon.ShutdownModule;
-import netflix.karyon.archaius.ArchaiusSuite;
+import netflix.karyon.archaius.ArchaiusBootstrapModule;
 import netflix.karyon.servo.KaryonServoModule;
 import rx.Observable;
 import rx.functions.Func1;
@@ -41,12 +41,12 @@ public final class WebSocketEchoServer {
         ).build();
         Karyon.forWebSocketServer(
                 webSocketServer,
-                new KaryonBootstrapSuite(),
-                new ArchaiusSuite("websocket-echo-server"),
-                // KaryonEurekaModule.asSuite(), /* Uncomment if you need eureka */
-                KaryonWebAdminModule.asSuite(),
-                ShutdownModule.asSuite(),
-                KaryonServoModule.asSuite())
+                new KaryonBootstrapModule(),
+                new ArchaiusBootstrapModule("websocket-echo-server"),
+                // KaryonEurekaModule.asBootstrapModule(), /* Uncomment if you need eureka */
+                KaryonWebAdminModule.asBootstrapModule(),
+                ShutdownModule.asBootstrapModule(),
+                KaryonServoModule.asBootstrapModule())
                 .startAndWaitTillShutdown();
     }
 }

--- a/karyon-governator/build.gradle
+++ b/karyon-governator/build.gradle
@@ -21,7 +21,7 @@ tasks.withType(Javadoc).each {
 
 dependencies {
     dependencies {
-        compile 'com.netflix.governator:governator:1.2.20'
+        compile "com.netflix.governator:governator:${governator_version}"
         compile project(':karyon-core')
     }
 }

--- a/karyon-governator/src/main/java/netflix/karyon/AbstractKaryonServer.java
+++ b/karyon-governator/src/main/java/netflix/karyon/AbstractKaryonServer.java
@@ -1,7 +1,7 @@
 package netflix.karyon;
 
 import com.google.inject.Injector;
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+import com.netflix.governator.guice.BootstrapModule;
 import com.netflix.governator.lifecycle.LifecycleManager;
 
 import java.util.Arrays;
@@ -11,27 +11,27 @@ import java.util.Arrays;
  */
 abstract class AbstractKaryonServer implements KaryonServer {
 
-    protected final LifecycleInjectorBuilderSuite[] suites;
+    protected final BootstrapModule[] bootstrapModules;
     protected LifecycleManager lifecycleManager;
     protected Injector injector;
 
-    public AbstractKaryonServer(LifecycleInjectorBuilderSuite... suites) {
-        this.suites = suites;
+    public AbstractKaryonServer(BootstrapModule... bootstrapModules) {
+        this.bootstrapModules = bootstrapModules;
     }
 
     @Override
     public final void start() {
-        startWithAdditionalSuites();
+        startWithAdditionalBootstrapModules();
     }
 
-    public final void startWithAdditionalSuites(LifecycleInjectorBuilderSuite... additionalSuites) {
-        LifecycleInjectorBuilderSuite[] applicableSuites = this.suites;
-        if (null != additionalSuites && additionalSuites.length != 0) {
-            applicableSuites = Arrays.copyOf(suites, suites.length + additionalSuites.length);
-            System.arraycopy(additionalSuites, 0, applicableSuites, suites.length, additionalSuites.length);
+    public final void startWithAdditionalBootstrapModules(BootstrapModule... additionalBootstrapModules) {
+        BootstrapModule[] applicableBootstrapModules = this.bootstrapModules;
+        if (null != additionalBootstrapModules && additionalBootstrapModules.length != 0) {
+            applicableBootstrapModules = Arrays.copyOf(bootstrapModules, bootstrapModules.length + additionalBootstrapModules.length);
+            System.arraycopy(additionalBootstrapModules, 0, applicableBootstrapModules, bootstrapModules.length, additionalBootstrapModules.length);
         }
 
-        injector = newInjector(applicableSuites);
+        injector = newInjector(applicableBootstrapModules);
 
         startLifecycleManager();
         _start();
@@ -52,7 +52,7 @@ abstract class AbstractKaryonServer implements KaryonServer {
         waitTillShutdown();
     }
 
-    protected abstract Injector newInjector(LifecycleInjectorBuilderSuite... applicableSuites);
+    protected abstract Injector newInjector(BootstrapModule... applicableBootstrapModules);
 
     protected void startLifecycleManager() {
         lifecycleManager = injector.getInstance(LifecycleManager.class);

--- a/karyon-governator/src/main/java/netflix/karyon/KaryonBootstrap.java
+++ b/karyon-governator/src/main/java/netflix/karyon/KaryonBootstrap.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@Bootstrap(KaryonBootstrapSuite.class)
+@Bootstrap(bootstrap = KaryonBootstrapModule.class)
 public @interface KaryonBootstrap {
 
     String name();

--- a/karyon-governator/src/main/java/netflix/karyon/KaryonRunner.java
+++ b/karyon-governator/src/main/java/netflix/karyon/KaryonRunner.java
@@ -1,6 +1,6 @@
 package netflix.karyon;
 
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+import com.netflix.governator.guice.BootstrapModule;
 import com.netflix.governator.guice.annotations.Bootstrap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +37,7 @@ public class KaryonRunner {
         System.out.println("Using main class: " + mainClassName);
 
         try {
-            Karyon.forApplication(Class.forName(mainClassName), (LifecycleInjectorBuilderSuite[]) null)
+            Karyon.forApplication(Class.forName(mainClassName), (BootstrapModule[]) null)
                   .startAndWaitTillShutdown();
         } catch (@SuppressWarnings("UnusedCatchParameter") ClassNotFoundException e) {
             System.out.println("Main class: " + mainClassName + " not found.");

--- a/karyon-governator/src/main/java/netflix/karyon/KaryonServerBackedServer.java
+++ b/karyon-governator/src/main/java/netflix/karyon/KaryonServerBackedServer.java
@@ -1,6 +1,6 @@
 package netflix.karyon;
 
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+import com.netflix.governator.guice.BootstrapModule;
 
 /**
  * An implementation of {@link KaryonServer} which wraps an existing {@link KaryonServer}.
@@ -10,16 +10,16 @@ import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
 class KaryonServerBackedServer implements KaryonServer {
 
     private final AbstractKaryonServer delegate;
-    private final LifecycleInjectorBuilderSuite[] suites;
+    private final BootstrapModule[] bootstrapModules;
 
-    KaryonServerBackedServer(AbstractKaryonServer delegate, LifecycleInjectorBuilderSuite... suites) {
+    KaryonServerBackedServer(AbstractKaryonServer delegate, BootstrapModule... bootstrapModules) {
         this.delegate = delegate;
-        this.suites = suites;
+        this.bootstrapModules = bootstrapModules;
     }
 
     @Override
     public void start() {
-        delegate.startWithAdditionalSuites(suites);
+        delegate.startWithAdditionalBootstrapModules(bootstrapModules);
     }
 
     @Override

--- a/karyon-governator/src/main/java/netflix/karyon/MainClassBasedServer.java
+++ b/karyon-governator/src/main/java/netflix/karyon/MainClassBasedServer.java
@@ -1,8 +1,8 @@
 package netflix.karyon;
 
 import com.google.inject.Injector;
+import com.netflix.governator.guice.BootstrapModule;
 import com.netflix.governator.guice.LifecycleInjector;
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,8 +17,8 @@ class MainClassBasedServer extends AbstractKaryonServer {
 
     private final Class<?> mainClass;
 
-    protected MainClassBasedServer(Class<?> mainClass, LifecycleInjectorBuilderSuite... suites) {
-        super(suites);
+    protected MainClassBasedServer(Class<?> mainClass, BootstrapModule... bootstrapModules) {
+        super(bootstrapModules);
         this.mainClass = mainClass;
     }
 
@@ -53,7 +53,7 @@ class MainClassBasedServer extends AbstractKaryonServer {
     }
 
     @Override
-    protected Injector newInjector(LifecycleInjectorBuilderSuite... applicableSuites) {
-        return LifecycleInjector.bootstrap(mainClass, applicableSuites);
+    protected Injector newInjector(BootstrapModule... applicableBootstrapModules) {
+        return LifecycleInjector.bootstrap(mainClass, applicableBootstrapModules);
     }
 }

--- a/karyon-governator/src/main/java/netflix/karyon/RxNettyServerBackedServer.java
+++ b/karyon-governator/src/main/java/netflix/karyon/RxNettyServerBackedServer.java
@@ -1,6 +1,6 @@
 package netflix.karyon;
 
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+import com.netflix.governator.guice.BootstrapModule;
 import io.reactivex.netty.server.AbstractServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,8 +16,8 @@ class RxNettyServerBackedServer extends MainClassBasedServer {
 
     @SuppressWarnings("rawtypes") private final AbstractServer rxNettyServer;
 
-    RxNettyServerBackedServer(AbstractServer rxNettyServer, LifecycleInjectorBuilderSuite... suites) {
-        super(RxNettyServerBackedServer.class, suites);
+    RxNettyServerBackedServer(AbstractServer rxNettyServer, BootstrapModule... bootstrapModules) {
+        super(RxNettyServerBackedServer.class, bootstrapModules);
         this.rxNettyServer = rxNettyServer;
     }
 

--- a/karyon-governator/src/main/java/netflix/karyon/ShutdownModule.java
+++ b/karyon-governator/src/main/java/netflix/karyon/ShutdownModule.java
@@ -6,8 +6,7 @@ import com.google.inject.Singleton;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
-import com.netflix.governator.guice.LifecycleInjectorBuilder;
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+import com.netflix.governator.guice.BootstrapModule;
 import com.netflix.governator.lifecycle.LifecycleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,17 +49,12 @@ public class ShutdownModule extends AbstractModule {
         return bind(Action0.class).annotatedWith(Names.named("afterShutdownAction"));
     }
 
-    public static LifecycleInjectorBuilderSuite asSuite() {
-        return asSuite(7002);
+    public static BootstrapModule asBootstrapModule() {
+        return asBootstrapModule(7002);
     }
 
-    public static LifecycleInjectorBuilderSuite asSuite(final int port) {
-        return new LifecycleInjectorBuilderSuite() {
-            @Override
-            public void configure(LifecycleInjectorBuilder builder) {
-                builder.withAdditionalModules(new ShutdownModule(port));
-            }
-        };
+    public static BootstrapModule asBootstrapModule(final int port) {
+        return Karyon.toBootstrapModule(new ShutdownModule(port));
     }
 
     @Singleton

--- a/karyon-jersey-blocking/build.gradle
+++ b/karyon-jersey-blocking/build.gradle
@@ -29,8 +29,8 @@ apply from: file('../gradle/license.gradle')
 
 dependencies {
     compile project(':karyon-governator')
-    compile 'com.google.guava:guava:11.0.2'
-    compile 'com.netflix.archaius:archaius-core:0.6.0'
+    compile 'com.google.guava:guava:14.0.1'
+    compile 'com.netflix.archaius:archaius-core:0.6.3'
     compile "com.sun.jersey:jersey-core:${jersey_version}"
     compile "com.sun.jersey.contribs:jersey-guice:${jersey_version}"
     compile "com.sun.jersey:jersey-servlet:${jersey_version}"

--- a/karyon-servo/build.gradle
+++ b/karyon-servo/build.gradle
@@ -22,7 +22,7 @@ tasks.withType(Javadoc).each {
 dependencies {
     dependencies {
         compile project(':karyon-governator')
-        compile "com.netflix.rxnetty:rx-netty-servo:${rxnetty_version}"
+        compile "io.reactivex:rxnetty-servo:${rxnetty_version}"
     }
 }
 

--- a/karyon-servo/src/main/java/netflix/karyon/servo/KaryonServoModule.java
+++ b/karyon-servo/src/main/java/netflix/karyon/servo/KaryonServoModule.java
@@ -1,27 +1,24 @@
 package netflix.karyon.servo;
 
 import com.google.inject.AbstractModule;
-import com.netflix.governator.guice.LifecycleInjectorBuilder;
-import com.netflix.governator.guice.LifecycleInjectorBuilderSuite;
+import com.netflix.governator.guice.BootstrapModule;
 import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.servo.ServoEventsListenerFactory;
+import netflix.karyon.Karyon;
 
 /**
+ * Register global RxNetty's Metric Listeners Factory to use Servo.
+ *
  * @author Nitesh Kant
  */
-public class KaryonServoModule extends AbstractModule{
+public class KaryonServoModule extends AbstractModule {
 
     @Override
     protected void configure() {
         RxNetty.useMetricListenersFactory(new ServoEventsListenerFactory());
     }
 
-    public static LifecycleInjectorBuilderSuite asSuite() {
-        return new LifecycleInjectorBuilderSuite() {
-            @Override
-            public void configure(LifecycleInjectorBuilder builder) {
-                builder.withAdditionalModules(new KaryonServoModule());
-            }
-        };
+    public static BootstrapModule asBootstrapModule() {
+        return Karyon.toBootstrapModule(KaryonServoModule.class);
     }
 }


### PR DESCRIPTION
BREAKING: Move away from LifecycleInjectorBuilder and suites in favor of just Bootstrap module. I tried to keep the naming consistent, hence removing references to "suite".