### PR TITLE
using ephemeral admin port for test

### DIFF
--- a/karyon-admin/src/main/java/netflix/adminresources/AdminPageRegistry.java
+++ b/karyon-admin/src/main/java/netflix/adminresources/AdminPageRegistry.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class AdminPageRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(AdminPageRegistry.class);
     public final static String PROP_ID_ADMIN_PAGES_SCAN = "netflix.platform.admin.pages.packages";
+    public static final String DEFAULT_SCAN_PKG = "netflix";
 
     private Map<String, AdminPageInfo> baseServerPageInfoMap = new ConcurrentHashMap<String, AdminPageInfo>();
 
@@ -99,7 +100,7 @@ public class AdminPageRegistry {
     }
 
     private List<String> getAdminPagesPackagesToScan() {
-        final String adminPagesPkgPath = ConfigurationManager.getConfigInstance().getString(PROP_ID_ADMIN_PAGES_SCAN, "com.netflix");
+        final String adminPagesPkgPath = ConfigurationManager.getConfigInstance().getString(PROP_ID_ADMIN_PAGES_SCAN, DEFAULT_SCAN_PKG);
         String[] pkgPaths = adminPagesPkgPath.split(";");
         return Lists.newArrayList(pkgPaths);
     }

--- a/karyon-admin/src/test/java/netflix/adminresources/AdminResourceTest.java
+++ b/karyon-admin/src/test/java/netflix/adminresources/AdminResourceTest.java
@@ -29,6 +29,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -45,17 +46,22 @@ public class AdminResourceTest {
         container.shutdown();
     }
 
+    @Before
+    public void init() {
+        System.setProperty(AdminResourcesContainer.CONTAINER_LISTEN_PORT, "0");
+    }
+
     @Test
     public void testBasic() throws Exception {
-        startServer();
+        final int port = startServerAndGetListeningPort();
         HttpClient client = new DefaultHttpClient();
         HttpGet healthGet =
-                new HttpGet("http://localhost:" + AdminResourcesContainer.LISTEN_PORT_DEFAULT + "/healthcheck");
+                new HttpGet(String.format("http://localhost:%d/healthcheck", port));
         HttpResponse response = client.execute(healthGet);
         Assert.assertEquals("admin resource health check failed.", 200, response.getStatusLine().getStatusCode());
     }
 
-    private void startServer() throws Exception {
+    private int startServerAndGetListeningPort() throws Exception {
         container = new AdminResourcesContainer(new Provider<HealthCheckInvocationStrategy>() {
             @Override
             public HealthCheckInvocationStrategy get() {
@@ -68,5 +74,7 @@ public class AdminResourceTest {
             }
         });
         container.init();
+
+        return container.getListenPort();
     }
 }


### PR DESCRIPTION
1. using dynamic configuration (archaius) instead of governator configuration annotation for admin console port, jersey packages
2. admin console port 0 is used for unit test which essentially makes jetty find an unused port to start server. 
3. default admin pages scan path moved to "netflix" 