### PR TITLE
karyon governator 1.3.3 integration fix

### DIFF
--- a/karyon-governator/src/main/java/netflix/karyon/KaryonBootstrapModule.java
+++ b/karyon-governator/src/main/java/netflix/karyon/KaryonBootstrapModule.java
@@ -48,9 +48,6 @@ public class KaryonBootstrapModule implements BootstrapModule {
     @Override
     public void configure(BootstrapBinder bootstrapBinder) {
         bootstrapBinder.inMode(LifecycleInjectorMode.SIMULATED_CHILD_INJECTORS);
-        if (null != karyonBootstrap) {
-            bootstrapBinder.bind(KaryonBootstrap.class).toInstance(karyonBootstrap);
-        }
         bootstrapBinder.include(new AbstractModule() {
             @Override
             protected void configure() {


### PR DESCRIPTION
KaryonBootstrap gets bound in LifecycleInjector with BootStrap module discovery for KaryonBootstrap annotation. Hence removing a double binding from KaryonBootstrapModule to prevent guice bootstrap error