### PR TITLE
Fixes #200 #122

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,9 @@
 #
 org.gradle.daemon=true
 
-rxnetty_version=0.4.4
+rxnetty_version=0.4.7
 jersey_version=1.18.1
 governator_version=1.3.3
 pytheas_version=1.25
 apache_httpclient_version=4.2.1
-eureka_version=1.1.147
+eureka_version=1.1.150

--- a/karyon2-core/src/main/java/netflix/karyon/health/HealthCheckInvocationStrategy.java
+++ b/karyon2-core/src/main/java/netflix/karyon/health/HealthCheckInvocationStrategy.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * A strategy to make application specific healthchecks. Since, the application health checks can be poorly implemented
  * and hence take a long time to complete, in some cases, it is wise to have an SLA around the health check response
- * times. <p></p>
+ * times.
  * There is a 1:1 mapping between a strategy instance and a {@link HealthCheckHandler} instance and hence it is assumed
  * that the strategy already knows about the handler instance.
  *

--- a/karyon2-core/src/main/java/netflix/karyon/transport/http/RegexUriConstraintKey.java
+++ b/karyon2-core/src/main/java/netflix/karyon/transport/http/RegexUriConstraintKey.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 /**
  * Provides constraint implementation for {@link netflix.karyon.transport.interceptor.InterceptorKey} for matching URI paths as regular expressions as
- * supported by {@link java.util.regex.Pattern}. <p></p>
+ * supported by {@link java.util.regex.Pattern}.
  * The request URI path is as retrieved using: {@link HttpKeyEvaluationContext#getRequestUriPath(HttpServerRequest)}
  *
  * @author Nitesh Kant

--- a/karyon2-core/src/main/java/netflix/karyon/transport/http/ServletStyleUriConstraintKey.java
+++ b/karyon2-core/src/main/java/netflix/karyon/transport/http/ServletStyleUriConstraintKey.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
  </ul>
  *
  * In any of the pattersn above the leading slash in the constraint is optional, i.e., "/myresource/foo" is equivalent to
- * "myresource/foo". <p></p>
+ * "myresource/foo".
  *
  * As compared to servlets/web applications there are no context paths of an application so the URI path has to be
  * absolute. <br>

--- a/karyon2-core/src/main/java/netflix/karyon/transport/http/SimpleUriRouter.java
+++ b/karyon2-core/src/main/java/netflix/karyon/transport/http/SimpleUriRouter.java
@@ -42,7 +42,7 @@ public class SimpleUriRouter<I, O> implements RequestHandler<I, O> {
     }
 
     /**
-     * Add a new URI -> Handler route to this router.
+     * Add a new URI -&lt; Handler route to this router.
      * @param uri URI to match.
      * @param handler Request handler.
      * @return The updated router.
@@ -53,7 +53,7 @@ public class SimpleUriRouter<I, O> implements RequestHandler<I, O> {
     }
 
     /**
-     * Add a new URI regex -> Handler route to this router.
+     * Add a new URI regex -&lt; Handler route to this router.
      * @param uriRegEx URI regex to match
      * @param handler Request handler.
      * @return The updated router.

--- a/karyon2-core/src/main/java/netflix/karyon/transport/interceptor/InterceptorExecutor.java
+++ b/karyon2-core/src/main/java/netflix/karyon/transport/interceptor/InterceptorExecutor.java
@@ -67,7 +67,10 @@ public class InterceptorExecutor<I, O, C extends KeyEvaluationContext> {
             @Override
             public Subscriber<? super Void> call(Subscriber<? super Void> child) {
                 SerialSubscription subscription = new SerialSubscription();
-                return new ChainSubscriber(subscription, context, request, response, child);
+                ChainSubscriber chainSubscriber = new ChainSubscriber(subscription, context, request, response, child);
+                subscription.set(chainSubscriber);
+                child.add(subscription);
+                return chainSubscriber;
             }
         });
     }

--- a/karyon2-core/src/main/java/netflix/karyon/transport/interceptor/KeyEvaluationContext.java
+++ b/karyon2-core/src/main/java/netflix/karyon/transport/interceptor/KeyEvaluationContext.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A context to store results of costly operations during evaluation of filter keys, eg: request URI parsing. <p></p>
+ * A context to store results of costly operations during evaluation of filter keys, eg: request URI parsing.
  * <b>This context is not thread-safe.</b>
  */
 public class KeyEvaluationContext {

--- a/karyon2-core/src/test/java/netflix/karyon/server/interceptor/InterceptorExecutorTest.java
+++ b/karyon2-core/src/test/java/netflix/karyon/server/interceptor/InterceptorExecutorTest.java
@@ -74,6 +74,22 @@ public class InterceptorExecutorTest {
         Assert.assertTrue("Tail interceptor did not get invoked.", router.isReceivedACall());
     }
 
+    @Test
+    public void testUnsubscribe() throws Exception {
+
+        TestableRequestRouter<ByteBuf, ByteBuf> router = new TestableRequestRouter<ByteBuf, ByteBuf>();
+
+        InterceptorSupport<ByteBuf, ByteBuf, KeyEvaluationContext> support = new InterceptorSupport<ByteBuf, ByteBuf, KeyEvaluationContext>();
+
+        InterceptorExecutor<ByteBuf, ByteBuf, KeyEvaluationContext> executor =
+                new InterceptorExecutor<ByteBuf, ByteBuf, KeyEvaluationContext>(support, router);
+
+        executeAndAwait(executor);
+
+        Assert.assertTrue("Router did not get invoked.", router.isReceivedACall());
+        Assert.assertTrue("Router did not get unsubscribed.", router.isUnsubscribed());
+    }
+
     protected void executeAndAwait(InterceptorExecutor<ByteBuf, ByteBuf, KeyEvaluationContext> executor)
             throws InterruptedException {
         final CountDownLatch completionLatch = new CountDownLatch(1);

--- a/karyon2-core/src/test/java/netflix/karyon/server/interceptor/TestableRequestRouter.java
+++ b/karyon2-core/src/test/java/netflix/karyon/server/interceptor/TestableRequestRouter.java
@@ -2,6 +2,7 @@ package netflix.karyon.server.interceptor;
 
 import io.reactivex.netty.channel.Handler;
 import rx.Observable;
+import rx.functions.Action0;
 
 /**
 * @author Nitesh Kant
@@ -9,14 +10,24 @@ import rx.Observable;
 class TestableRequestRouter<I, O> implements Handler<I, O> {
 
     private volatile boolean called;
+    private volatile boolean unsubscribed;
 
     public boolean isReceivedACall() {
         return called;
     }
 
+    public boolean isUnsubscribed() {
+        return unsubscribed;
+    }
+
     @Override
     public Observable<Void> handle(I input, O output) {
         called = true;
-        return Observable.empty();
+        return Observable.<Void>empty().doOnUnsubscribe(new Action0() {
+            @Override
+            public void call() {
+                unsubscribed = true;
+            }
+        });
     }
 }

--- a/karyon2-examples/src/main/java/netflix/karyon/examples/hellonoss/server/rxnetty/MyApplicationRunner.java
+++ b/karyon2-examples/src/main/java/netflix/karyon/examples/hellonoss/server/rxnetty/MyApplicationRunner.java
@@ -1,34 +1,18 @@
 package netflix.karyon.examples.hellonoss.server.rxnetty;
 
-import com.google.inject.AbstractModule;
 import netflix.adminresources.resources.KaryonWebAdminModule;
 import netflix.karyon.Karyon;
 import netflix.karyon.KaryonBootstrapModule;
 import netflix.karyon.ShutdownModule;
 import netflix.karyon.archaius.ArchaiusBootstrapModule;
 import netflix.karyon.examples.hellonoss.common.health.HealthCheck;
-import netflix.karyon.health.HealthCheckHandler;
 import netflix.karyon.servo.KaryonServoModule;
 import netflix.karyon.transport.http.health.HealthCheckEndpoint;
-
-import javax.ws.rs.core.Response;
 
 /**
  * @author Nitesh Kant
  */
 public class MyApplicationRunner {
-
-    public static class HealthCheckHandlerModule extends AbstractModule {
-        @Override
-        protected void configure() {
-            bind(HealthCheckHandler.class).toInstance(new HealthCheckHandler() {
-                @Override
-                public int getStatus() {
-                    return Response.Status.OK.getStatusCode();
-                }
-            });
-        }
-    }
 
     public static void main(String[] args) {
         HealthCheck healthCheckHandler = new HealthCheck();
@@ -40,9 +24,7 @@ public class MyApplicationRunner {
                 // KaryonEurekaModule.asBootstrapModule(), /* Uncomment if you need eureka */
                 Karyon.toBootstrapModule(KaryonWebAdminModule.class),
                 ShutdownModule.asBootstrapModule(),
-                KaryonServoModule.asBootstrapModule(),
-                Karyon.toBootstrapModule(HealthCheckHandlerModule.class)
-        )
-                .startAndWaitTillShutdown();
+                KaryonServoModule.asBootstrapModule()
+        ).startAndWaitTillShutdown();
     }
 }


### PR DESCRIPTION
`InterceptorExecutor` was not adding unsubscribe hooks to the child when there were no interceptors.

- Fixed javadoc errors
- Upgraded rxnetty & eureka versions