### PR TITLE
admin plugin support for additional guice modules

### DIFF
--- a/karyon2-admin-plugins/karyon2-admin-healthcheck-plugin/src/test/java/netflix/adminresources/HealthCheckResourceTest.java
+++ b/karyon2-admin-plugins/karyon2-admin-healthcheck-plugin/src/test/java/netflix/adminresources/HealthCheckResourceTest.java
@@ -26,7 +26,7 @@ public class HealthCheckResourceTest {
     @After
     public void tearDown() throws Exception {
         final AbstractConfiguration configInst = ConfigurationManager.getConfigInstance();
-        configInst.clearProperty(AdminResourcesContainer.CONTAINER_LISTEN_PORT);
+        configInst.clearProperty(AdminConfigImpl.CONTAINER_LISTEN_PORT);
         if (container != null) {
             container.shutdown();
         }
@@ -34,7 +34,7 @@ public class HealthCheckResourceTest {
 
     @Before
     public void init() {
-        System.setProperty(AdminResourcesContainer.CONTAINER_LISTEN_PORT, "0");
+        System.setProperty(AdminConfigImpl.CONTAINER_LISTEN_PORT, "0");
         System.setProperty(AdminConfigImpl.NETFLIX_ADMIN_RESOURCE_CONTEXT, "/jr");
     }
 

--- a/karyon2-admin-web/src/main/java/netflix/adminresources/pages/AdminPageResource.java
+++ b/karyon2-admin-web/src/main/java/netflix/adminresources/pages/AdminPageResource.java
@@ -18,6 +18,7 @@ import com.sun.jersey.api.view.Viewable;
 import netflix.admin.AdminContainerConfig;
 import netflix.adminresources.AdminPageInfo;
 import netflix.adminresources.AdminPageRegistry;
+import netflix.adminresources.AdminResourcesContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,9 +31,9 @@ public class AdminPageResource {
     private final AdminPageRegistry adminPageRegistry;
 
     @Inject
-    public AdminPageResource(AdminPageRegistry adminPageRegistry, AdminContainerConfig adminContainerConfig) {
+    public AdminPageResource(AdminContainerConfig adminContainerConfig, AdminResourcesContainer adminResourcesContainer) {
         this.adminContainerConfig = adminContainerConfig;
-        this.adminPageRegistry = adminPageRegistry;
+        this.adminPageRegistry = adminResourcesContainer.getAdminPageRegistry();
     }
 
     @GET()

--- a/karyon2-admin-web/src/test/java/netflix/adminresources/WebAdminTest.java
+++ b/karyon2-admin-web/src/test/java/netflix/adminresources/WebAdminTest.java
@@ -18,6 +18,7 @@ package netflix.adminresources;
 
 import com.google.common.collect.ImmutableMap;
 import com.netflix.config.ConfigurationManager;
+import netflix.admin.AdminConfigImpl;
 import netflix.adminresources.resources.MaskedResourceHelper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -53,7 +54,7 @@ public class WebAdminTest {
         System.setProperty("AWS_SECRET_KEY", "super-secret-aws-key");
         System.setProperty("AWS_ACCESS_ID", "super-aws-access-id");
         System.setProperty(MaskedResourceHelper.MASKED_PROPERTY_NAMES, "AWS_SECRET_KEY");
-        System.setProperty(AdminResourcesContainer.CONTAINER_LISTEN_PORT, "0");
+        System.setProperty(AdminConfigImpl.CONTAINER_LISTEN_PORT, "0");
 
         adminServerPort = startServerAndGetListeningPort();
         buildUpRestEndpointsToTest();

--- a/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
@@ -8,15 +8,33 @@ import javax.inject.Singleton;
 public class AdminConfigImpl implements AdminContainerConfig {
     public static final String NETFLIX_ADMIN_TEMPLATE_CONTEXT = "netflix.admin.template.context";
     public static final String TEMPLATE_CONTEXT_DEFAULT = "/admin";
+
     public static final String NETFLIX_ADMIN_RESOURCE_CONTEXT = "netflix.admin.resource.context";
     public static final String RESOURCE_CONTEXT_DEFAULT = "/webadmin";
+
+    private static final String JERSEY_CORE_RESOURCES = "netflix.platform.admin.resources.core.packages";
+    public static final String JERSEY_CORE_RESOURCES_DEFAULT = "netflix.adminresources;com.netflix.explorers.resources;com.netflix.explorers.providers";
+
+    private static final String JERSEY_VIEWABLE_RESOURCES = "netflix.platform.admin.resources.viewable.packages";
+    public static final String JERSEY_VIEWABLE_RESOURCES_DEFAULT = "netflix.admin;netflix.adminresources.pages;com.netflix.explorers.resources";
+
+    public static final String CONTAINER_LISTEN_PORT = "netflix.platform.admin.resources.port";
+    public static final int LISTEN_PORT_DEFAULT = 8077;
+
     private final String templateResContext;
     private final String resourceContext;
+    private final String coreJerseyResources;
+    private final String viewableResources;
+    private final int listenPort;
 
     public AdminConfigImpl() {
         templateResContext = ConfigurationManager.getConfigInstance().getString(NETFLIX_ADMIN_TEMPLATE_CONTEXT, TEMPLATE_CONTEXT_DEFAULT);
         resourceContext = ConfigurationManager.getConfigInstance().getString(NETFLIX_ADMIN_RESOURCE_CONTEXT, RESOURCE_CONTEXT_DEFAULT);
+        coreJerseyResources = ConfigurationManager.getConfigInstance().getString(JERSEY_CORE_RESOURCES, JERSEY_CORE_RESOURCES_DEFAULT);
+        viewableResources = ConfigurationManager.getConfigInstance().getString(JERSEY_VIEWABLE_RESOURCES, JERSEY_VIEWABLE_RESOURCES_DEFAULT);
+        listenPort = ConfigurationManager.getConfigInstance().getInt(CONTAINER_LISTEN_PORT, LISTEN_PORT_DEFAULT);
     }
+
 
     @Override
     public String templateResourceContext() {
@@ -26,5 +44,25 @@ public class AdminConfigImpl implements AdminContainerConfig {
     @Override
     public String ajaxDataResourceContext() {
         return resourceContext;
+    }
+
+    @Override
+    public String jerseyResourcePkgList() {
+        return coreJerseyResources;
+    }
+
+    @Override
+    public String jerseyViewableResourcePkgList() {
+        return viewableResources;
+    }
+
+    @Override
+    public boolean shouldScanClassPathForPluginDiscovery() {
+        return true;
+    }
+
+    @Override
+    public int listenPort() {
+        return listenPort;
     }
 }

--- a/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
@@ -3,4 +3,8 @@ package netflix.admin;
 public interface AdminContainerConfig {
     String templateResourceContext();
     String ajaxDataResourceContext();
+    String jerseyResourcePkgList();
+    String jerseyViewableResourcePkgList();
+    boolean shouldScanClassPathForPluginDiscovery();
+    int listenPort();
 }

--- a/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
@@ -1,5 +1,8 @@
 package netflix.admin;
 
+import com.google.inject.ImplementedBy;
+
+@ImplementedBy(AdminConfigImpl.class)
 public interface AdminContainerConfig {
     String templateResourceContext();
     String ajaxDataResourceContext();

--- a/karyon2-admin/src/main/java/netflix/adminresources/AbstractAdminPageInfo.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AbstractAdminPageInfo.java
@@ -1,8 +1,11 @@
 package netflix.adminresources;
 
+import com.google.inject.Module;
 import com.netflix.config.ConfigurationManager;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractAdminPageInfo implements AdminPageInfo {
@@ -41,6 +44,11 @@ public abstract class AbstractAdminPageInfo implements AdminPageInfo {
         final String disablePagePropId = ADMIN_PAGE_DISABLE_PROP_PREFIX + pageId + DISABLED;
         boolean isDisabled = ConfigurationManager.getConfigInstance().getBoolean(disablePagePropId, false);
         return !isDisabled;
+    }
+
+    @Override
+    public List<Module> getGuiceModules() {
+        return new ArrayList<>(0);
     }
 
     @Override

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminPageInfo.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminPageInfo.java
@@ -1,5 +1,8 @@
 package netflix.adminresources;
 
+import com.google.inject.Module;
+
+import java.util.List;
 import java.util.Map;
 
 public interface AdminPageInfo {
@@ -17,6 +20,9 @@ public interface AdminPageInfo {
 
     // additional jersey resource package list if needed
     String getJerseyResourcePackageList();
+
+    // Guice modules that need to be added to the injector
+    List<Module> getGuiceModules();
 
     // controls if the module should be visible/enabled in admin console
     boolean isEnabled();

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminPageRegistry.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminPageRegistry.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 
-@Singleton
 public class AdminPageRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(AdminPageRegistry.class);
     public final static String PROP_ID_ADMIN_PAGES_SCAN = "netflix.platform.admin.pages.packages";
@@ -27,7 +26,12 @@ public class AdminPageRegistry {
     public final static String PROP_ID_ADMIN_PAGE_ANNOTATION = "netflix.platform.admin.pages.annotation";
     public static final String DEFAULT_ADMIN_PAGE_ANNOTATION = "netflix.adminresources.AdminPage";
 
-    private Map<String, AdminPageInfo> baseServerPageInfoMap = new ConcurrentHashMap<String, AdminPageInfo>();
+    private Map<String, AdminPageInfo> baseServerPageInfoMap;
+
+
+    public AdminPageRegistry() {
+        this.baseServerPageInfoMap = new ConcurrentHashMap<>();
+    }
 
     public void add(AdminPageInfo baseServerPageInfo) {
         Preconditions.checkNotNull(baseServerPageInfo);
@@ -59,15 +63,6 @@ public class AdminPageRegistry {
         return enabledPages;
     }
 
-    private List<AdminPageInfo> getEnabledPages(List<AdminPageInfo> pages) {
-        List<AdminPageInfo> enabledPages = Lists.newArrayList();
-        for (AdminPageInfo page : pages) {
-            if (page.isEnabled()) {
-                enabledPages.add(page);
-            }
-        }
-        return enabledPages;
-    }
 
     public void registerAdminPagesWithClasspathScan() {
         List<Class<? extends Annotation>> annotationList = getAdminPageAnnotations();
@@ -145,6 +140,16 @@ public class AdminPageRegistry {
             }
         }
         return clsList;
+    }
+
+    private List<AdminPageInfo> getEnabledPages(List<AdminPageInfo> pages) {
+        List<AdminPageInfo> enabledPages = Lists.newArrayList();
+        for (AdminPageInfo page : pages) {
+            if (page.isEnabled()) {
+                enabledPages.add(page);
+            }
+        }
+        return enabledPages;
     }
 }
 

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -166,7 +166,6 @@ public class AdminResourcesContainer {
         return new AbstractModule() {
             @Override
             protected void configure() {
-                bind(AdminContainerConfig.class).to(AdminConfigImpl.class);
                 bind(AdminResourcesFilter.class);
             }
         };

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -71,8 +71,10 @@ public class AdminResourcesContainer {
     @Inject(optional = true)
     private AdminContainerConfig adminContainerConfig;
 
-    private AtomicBoolean alreadyInited = new AtomicBoolean(false);
+    @Inject(optional = true)
     private AdminPageRegistry adminPageRegistry;
+
+    private AtomicBoolean alreadyInited = new AtomicBoolean(false);
     private int serverPort; // actual server listen port (apart from what's in Config)
 
     /**
@@ -85,8 +87,8 @@ public class AdminResourcesContainer {
         try {
             if (alreadyInited.compareAndSet(false, true)) {
                 initAdminContainerConfigIfNeeded();
+                initAdminRegistryIfNeeded();
 
-                adminPageRegistry = new AdminPageRegistry();
                 if (adminContainerConfig.shouldScanClassPathForPluginDiscovery()) {
                     adminPageRegistry.registerAdminPagesWithClasspathScan();
                 }
@@ -151,6 +153,12 @@ public class AdminResourcesContainer {
     private void initAdminContainerConfigIfNeeded() {
         if (adminContainerConfig == null) {
             adminContainerConfig = new AdminConfigImpl();
+        }
+    }
+
+    private void initAdminRegistryIfNeeded() {
+        if (adminPageRegistry == null) {
+            adminPageRegistry = new AdminPageRegistry();
         }
     }
 

--- a/karyon2-admin/src/test/java/netflix/adminresources/AdminResourceTest.java
+++ b/karyon2-admin/src/test/java/netflix/adminresources/AdminResourceTest.java
@@ -64,7 +64,7 @@ public class AdminResourceTest {
     @After
     public void tearDown() throws Exception {
         final AbstractConfiguration configInst = ConfigurationManager.getConfigInstance();
-        configInst.clearProperty(AdminResourcesContainer.CONTAINER_LISTEN_PORT);
+        configInst.clearProperty(AdminConfigImpl.CONTAINER_LISTEN_PORT);
         if (container != null) {
             container.shutdown();
         }
@@ -72,7 +72,7 @@ public class AdminResourceTest {
 
     @BeforeClass
     public static void init() {
-        setConfig(AdminResourcesContainer.CONTAINER_LISTEN_PORT, "0");
+        setConfig(AdminConfigImpl.CONTAINER_LISTEN_PORT, "0");
         setConfig(AdminConfigImpl.NETFLIX_ADMIN_RESOURCE_CONTEXT, "/jr");
         setConfig(AdminConfigImpl.NETFLIX_ADMIN_TEMPLATE_CONTEXT, "/main");
     }


### PR DESCRIPTION
1. AdminPage plugin can provide a list of guice bindings that a plugin author can create. The modules will be included in the Guice injector that is created as a result of AdminResourceContainer startup routine.

2. AdminResourceContainer defined as a singleton has an instance of AdminPageRegistry that can be accessed with a getter. 

3. AdminResourceContainer allows setting a listenport explicitly. This along with #2 allows for potentially running multiple instances of AdminResourceContainers within a single JVM with a separate AdminPageRegistry associated with each instance.

