### PR TITLE
Adding back reference to CONTAINER_LISTEN_PORT in AdminResourceContainer for backwards compatibility

### DIFF
--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -63,6 +63,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Singleton
 public class AdminResourcesContainer {
     private static final Logger logger = LoggerFactory.getLogger(AdminResourcesContainer.class);
+
+    /**
+     * @deprecated here for backwards compatibility. Use {@link AdminConfigImpl#CONTAINER_LISTEN_PORT}.
+     */
+    @Deprecated
+    public static final String CONTAINER_LISTEN_PORT = AdminConfigImpl.CONTAINER_LISTEN_PORT;
+
     private Server server;
 
     @Inject(optional = true)


### PR DESCRIPTION
Eureka2 has a dependency on karyon snapshot (something that eureka will need to fix) that references this variable. Since snapshot artifacts are malleable this removal breaks current eureka2 rc.1. Adding it back here for migration backwards compatibility.