### PR TITLE
Fix for: Karyon Jersey Blocking ( partial read + memory leak )

### DIFF
--- a/karyon2-jersey-blocking/src/main/java/netflix/karyon/jersey/blocking/NettyToJerseyBridge.java
+++ b/karyon2-jersey-blocking/src/main/java/netflix/karyon/jersey/blocking/NettyToJerseyBridge.java
@@ -6,17 +6,16 @@ import com.sun.jersey.spi.container.ContainerResponse;
 import com.sun.jersey.spi.container.ContainerResponseWriter;
 import com.sun.jersey.spi.container.WebApplication;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.netty.protocol.http.server.HttpRequestHeaders;
 import io.reactivex.netty.protocol.http.server.HttpResponseHeaders;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
-import netflix.karyon.transport.util.HttpContentInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -43,13 +42,13 @@ final class NettyToJerseyBridge {
         this.application = application;
     }
 
-    ContainerRequest bridgeRequest(final HttpServerRequest<ByteBuf> nettyRequest, ByteBufAllocator allocator) {
+    ContainerRequest bridgeRequest(final HttpServerRequest<ByteBuf> nettyRequest, InputStream requestData ) {
         try {
             URI baseUri = new URI("/"); // Since the netty server does not have a context path element as such, so base uri is always /
             URI uri = new URI(nettyRequest.getUri());
             return new ContainerRequest(application, nettyRequest.getHttpMethod().name(),
                                         baseUri, uri, new JerseyRequestHeadersAdapter(nettyRequest.getHeaders()),
-                                        new HttpContentInputStream(allocator, nettyRequest.getContent()));
+                                        requestData );
         } catch (URISyntaxException e) {
             logger.error(String.format("Invalid request uri: %s", nettyRequest.getUri()), e);
             throw new IllegalArgumentException(e);

--- a/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JerseyBlockingModule.java
+++ b/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JerseyBlockingModule.java
@@ -30,9 +30,6 @@ public interface JerseyBlockingModule {
   class KaryonRxRouterModuleImpl extends KaryonJerseyModule {
     @Override
     protected void configureServer() {
-      
-      //we need intercepter, otherwise RxJava will leak scheduler threads
-      //interceptorSupport().forUri("/*").intercept(AccessInterceptor.class);
       server().port( 7001 ).threadPoolSize( 200 );
     }
   }

--- a/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JerseyBlockingModule.java
+++ b/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JerseyBlockingModule.java
@@ -1,0 +1,52 @@
+package netflix.karyon.jersey.blocking;
+
+import static com.netflix.config.ConfigurationManager.getConfigInstance;
+import io.netty.buffer.ByteBuf;
+import io.reactivex.netty.protocol.http.server.HttpServerRequest;
+import io.reactivex.netty.protocol.http.server.HttpServerResponse;
+import netflix.karyon.KaryonBootstrap;
+import rx.Observable;
+import netflix.karyon.transport.interceptor.DuplexInterceptor;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+import com.netflix.governator.annotations.Modules;
+
+@KaryonBootstrap( name = "jersey-blocking" )
+@Singleton
+@Modules(include = {
+        JerseyBlockingModule.TestModule.class,
+        JerseyBlockingModule.KaryonRxRouterModuleImpl.class,
+})
+public interface JerseyBlockingModule {
+  class TestModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        getConfigInstance().addProperty("com.sun.jersey.config.property.packages", "netflix.karyon.jersey.blocking");       
+    }
+  }
+  
+  class KaryonRxRouterModuleImpl extends KaryonJerseyModule {
+    @Override
+    protected void configureServer() {
+      
+      //we need intercepter, otherwise RxJava will leak scheduler threads
+      //interceptorSupport().forUri("/*").intercept(AccessInterceptor.class);
+      server().port( 7001 ).threadPoolSize( 200 );
+    }
+  }
+  
+  public class AccessInterceptor implements DuplexInterceptor<HttpServerRequest<ByteBuf>, HttpServerResponse<ByteBuf>> {
+    @Override
+    public Observable<Void> in(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+      return Observable.empty();
+    }
+
+    @Override
+    public Observable<Void> out(HttpServerResponse<ByteBuf> response) {
+      return Observable.empty();
+    }
+  }
+  
+}

--- a/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JerseyBlockingTest.java
+++ b/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JerseyBlockingTest.java
@@ -1,0 +1,160 @@
+package netflix.karyon.jersey.blocking;
+
+import static org.junit.Assert.assertEquals;
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ResourceLeak;
+import io.netty.util.ResourceLeakDetector;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Filter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import netflix.karyon.Karyon;
+import netflix.karyon.KaryonServer;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.netflix.governator.guice.BootstrapModule;
+
+public class JerseyBlockingTest {
+  private static KaryonServer server; 
+  
+  static ByteArrayOutputStream buffer;
+  
+  @BeforeClass
+  public static void setUpBefore() throws Exception {
+    server = Karyon.forApplication( JerseyBlockingModule.class, (BootstrapModule[])null );
+      
+    server.start();
+  }
+
+  @AfterClass
+  public static void cleanUpAfter() throws Exception {
+      server.shutdown();
+  }
+  
+  private static int postData( String path, String payload ) throws IOException {
+    URL url = new URL( path );
+
+    HttpURLConnection con = (HttpURLConnection)url.openConnection();
+    con.setRequestMethod("POST");
+    
+    con.setRequestProperty("Content-Type","application/json");
+
+    con.setDoOutput(true); 
+    con.setDoInput(true); 
+    con.setConnectTimeout( 10000 );
+    con.setReadTimeout( 20000 );
+    
+    con.getOutputStream().write( payload.getBytes("UTF-8") );
+    con.getOutputStream().flush();
+    con.getOutputStream().close();
+    
+    int status = con.getResponseCode();
+    
+    if( status != 200 ) {
+      return status;
+    }
+    
+    //read the response
+    byte[] buffer = new byte[ 1024 ];
+    while( con.getInputStream().read( buffer ) > 0 ) {
+        ;
+    }
+    
+    return 200;
+  }
+  
+  
+  private String makePayload( int size ) {
+    StringBuilder buffer = new StringBuilder();
+    
+    buffer.append("{\"key\":\"");
+    for( int i = 0; i < size; ++i ) {
+      buffer.append(( Byte.toString( (byte)( i & 0xFF ) ) ) );
+    }
+    
+    return buffer.append("\"}").toString();
+  }
+  
+  @Test
+  public void runJerseyTest() throws InterruptedException {
+    ExecutorService service = Executors.newCachedThreadPool();
+    
+    final Random rnd = new Random();
+    final AtomicInteger errors = new AtomicInteger();
+
+    //let Netty blow in our face
+    ResourceLeakDetector.setLevel( ResourceLeakDetector.Level.PARANOID );
+
+    //tap to the logger, so we can catch leak error
+    Logger.getLogger( "io.netty.util.ResourceLeakDetector" ).setFilter( new Filter() {
+      @Override
+      public boolean isLoggable(LogRecord record) {
+        if( record.getLevel() == Level.SEVERE && record.getMessage().contains("LEAK") ) {
+          errors.incrementAndGet();
+        }
+        
+        return true;
+      }
+    });
+    
+    for( int i = 0; i < 200; ++i ) {
+      service.execute( new Runnable() {
+        @Override
+        public void run() {
+          try {
+            int response = postData("http://localhost:7001/test", makePayload( Math.max(1, rnd.nextInt( 1024 ) ) ) );
+
+            if( response != 200 ) {
+              errors.addAndGet( 1 );
+            }
+          }
+          catch( Exception e ) {
+            errors.addAndGet( 1 );          }
+        }
+      });
+      
+      Thread.sleep( rnd.nextInt( 100 ) );
+    }
+
+    //aid netty leak detection
+    System.gc();
+    
+    for( int i = 0; i < 100; ++i ) {
+        try {
+            //do not exceeded Netty content length ~1M
+            int response = postData("http://localhost:7001/test", makePayload( Math.max(1, rnd.nextInt( 127 * 1024 ) ) ) );
+        
+            if( response != 200 ) {
+              errors.addAndGet( 1 );
+            }
+        }
+        catch( Exception e ) {
+            errors.addAndGet( 1 );          
+        }
+        
+        //aid netty leak detection
+        System.gc();
+    }
+
+    service.shutdown();
+    service.awaitTermination( 100, TimeUnit.SECONDS );
+    
+    assertEquals( "Errors: ", 0, errors.intValue() );
+  }
+  
+}

--- a/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JerseyBlockingTest.java
+++ b/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JerseyBlockingTest.java
@@ -1,13 +1,10 @@
 package netflix.karyon.jersey.blocking;
 
 import static org.junit.Assert.assertEquals;
-import io.netty.buffer.ByteBuf;
-import io.netty.util.ResourceLeak;
 import io.netty.util.ResourceLeakDetector;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Random;

--- a/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JsonReadingResource.java
+++ b/karyon2-jersey-blocking/src/test/java/netflix/karyon/jersey/blocking/JsonReadingResource.java
@@ -1,0 +1,38 @@
+package netflix.karyon.jersey.blocking;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+
+@Path("/test")  
+public class JsonReadingResource {
+  private final ObjectMapper mapper = new ObjectMapper();
+  
+  @SuppressWarnings("unused")
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Response processJson( String payload ) {
+    
+    try {
+      
+      System.out.println( "processing payload size: '" + payload.length() + "'" );
+      
+      JsonNode tree = mapper.readTree( payload );
+      
+      return Response.ok().build();
+    }
+    catch( Exception e ) {
+      System.err.println( "ERROR:" + e.getMessage() );
+      
+      return Response.serverError().build();
+    }
+  }
+}          
+                     


### PR DESCRIPTION
1. Partial data read in Jersey blocking
2. Memory leak, as the ByteBuf was not released

Unit tests to verify both issues