### PR TITLE
Fixed #214: Changed the Eureka client version to the latest version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ jersey_version=1.18.1
 governator_version=1.3.3
 pytheas_version=1.25
 apache_httpclient_version=4.2.1
-eureka_version=1.1.150
+eureka_version=1.1.151

--- a/karyon2-eureka/build.gradle
+++ b/karyon2-eureka/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'osgi'
 
 dependencies {
     compile project(':karyon2-governator')
-    compile 'com.netflix.eureka:eureka-client:1.1.146'
+    compile "com.netflix.eureka:eureka-client:${eureka_version}"
 }
 
 jar {


### PR DESCRIPTION
This PR will fix #214 by changing the eureka client version. Currently I updated the version inside gradle.properties and used that variable inside the karyon2-eureka project.