### PR TITLE
upgrading to jetty-9

### DIFF
--- a/karyon2-admin/build.gradle
+++ b/karyon2-admin/build.gradle
@@ -19,9 +19,9 @@ dependencies {
     dependencies {
         compile 'javax.ws.rs:jsr311-api:1.1.1'
         compile 'javax.servlet:servlet-api:2.5'
-        compile 'org.eclipse.jetty:jetty-server:7.6.7.v20120910'
-        compile 'org.eclipse.jetty:jetty-servlet:7.6.7.v20120910'
-        compile 'com.sun.jersey.contribs:jersey-guice:1.17.1'
+        compile 'org.eclipse.jetty:jetty-server:9.3.0.M1'
+        compile 'org.eclipse.jetty:jetty-servlet:9.3.0.M1'
+        compile 'com.sun.jersey.contribs:jersey-guice:${jersey_version}'
         compile "com.sun.jersey:jersey-servlet:${jersey_version}"
         compile "com.sun.jersey:jersey-server:${jersey_version}"
         compile 'com.google.inject.extensions:guice-servlet:3.0'

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -22,10 +22,9 @@ import com.netflix.governator.guice.LifecycleInjectorMode;
 import com.netflix.governator.lifecycle.LifecycleManager;
 import netflix.admin.AdminConfigImpl;
 import netflix.admin.AdminContainerConfig;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.DispatcherType;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.servlet.DispatcherType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -151,7 +151,7 @@ public class AdminResourcesContainer {
                 server.setHandler(handlers);
                 server.start();
 
-                final Connector connector = server.getConnectors()[0];
+                final ServerConnector connector = (ServerConnector) server.getConnectors()[0];
                 serverPort = connector.getLocalPort();
             }
         } catch (Exception e) {


### PR DESCRIPTION
jetty-9 has some backward compatibility issues with respect to its API. This change addresses them as well as the dependency upgrades