### PR TITLE
jetty-6 downgrade

### DIFF
--- a/karyon2-admin/build.gradle
+++ b/karyon2-admin/build.gradle
@@ -19,8 +19,7 @@ dependencies {
     dependencies {
         compile 'javax.ws.rs:jsr311-api:1.1.1'
         compile 'javax.servlet:servlet-api:2.5'
-        compile 'org.eclipse.jetty:jetty-server:9.3.0.M1'
-        compile 'org.eclipse.jetty:jetty-servlet:9.3.0.M1'
+        compile 'org.mortbay.jetty:jetty:6.1.26'
         compile 'com.sun.jersey.contribs:jersey-guice:${jersey_version}'
         compile "com.sun.jersey:jersey-servlet:${jersey_version}"
         compile "com.sun.jersey:jersey-server:${jersey_version}"


### PR DESCRIPTION
Embedding jetty-9 caused conflicts with Tomcat 6 (and a few Tomcat 7 versions) as jetty-9 pulls in servlet 3.1 which gets dropped by tomcat.
Hence going back to jetty-6 based on servlet 2.5