### PR TITLE
optional support for full resource isolation

### DIFF
--- a/karyon2-admin-web/src/main/java/netflix/adminresources/pages/AdminPageResource.java
+++ b/karyon2-admin-web/src/main/java/netflix/adminresources/pages/AdminPageResource.java
@@ -1,27 +1,21 @@
 package netflix.adminresources.pages;
 
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.sun.jersey.api.view.Viewable;
+import netflix.admin.AdminConfigImpl;
+import netflix.admin.AdminContainerConfig;
+import netflix.adminresources.AdminPageInfo;
+import netflix.adminresources.AdminPageRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.PostConstruct;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-import com.sun.jersey.api.view.Viewable;
-import netflix.admin.AdminContainerConfig;
-import netflix.adminresources.AdminPageInfo;
-import netflix.adminresources.AdminPageRegistry;
-import netflix.adminresources.AdminResourcesContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Path("/")
 @Produces(MediaType.TEXT_HTML)
@@ -29,18 +23,19 @@ import org.slf4j.LoggerFactory;
 public class AdminPageResource {
     private static final Logger LOG = LoggerFactory.getLogger(AdminPageResource.class);
 
-    @Inject(optional=true)
+    @Inject(optional = true)
     private AdminContainerConfig adminContainerConfig;
 
-    @Inject(optional=true)
-    private AdminResourcesContainer adminResourcesContainer;
-
+    @Inject(optional = true)
     private AdminPageRegistry adminPageRegistry;
 
     @PostConstruct
     public void init() {
-        if (adminResourcesContainer != null) {
-            adminPageRegistry = adminResourcesContainer.getAdminPageRegistry();
+        if (adminPageRegistry == null) {
+            adminPageRegistry = new AdminPageRegistry();
+        }
+        if (adminContainerConfig == null) {
+            adminContainerConfig = new AdminConfigImpl();
         }
     }
 

--- a/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
@@ -24,6 +24,9 @@ public class AdminConfigImpl implements AdminContainerConfig {
     public static final String SERVER_ENABLE_PROP_NAME = "netflix.platform.admin.resources.enable";
     public static final boolean SERVER_ENABLE_DEFAULT = true;
 
+    public static final String NETFLIX_ADMIN_RESOURCES_ISOLATE = "netflix.admin.resources.isolate";
+    public static final boolean ISOLATE_RESOURCES_DEFAULT = false;
+
 
     private final String templateResContext;
     private final String resourceContext;
@@ -31,6 +34,7 @@ public class AdminConfigImpl implements AdminContainerConfig {
     private final String viewableResources;
     private final int listenPort;
     private final boolean isEnabled;
+    private final boolean isResourcesIsolated;
 
     public AdminConfigImpl() {
         isEnabled = ConfigurationManager.getConfigInstance().getBoolean(SERVER_ENABLE_PROP_NAME, SERVER_ENABLE_DEFAULT);
@@ -39,6 +43,12 @@ public class AdminConfigImpl implements AdminContainerConfig {
         coreJerseyResources = ConfigurationManager.getConfigInstance().getString(JERSEY_CORE_RESOURCES, JERSEY_CORE_RESOURCES_DEFAULT);
         viewableResources = ConfigurationManager.getConfigInstance().getString(JERSEY_VIEWABLE_RESOURCES, JERSEY_VIEWABLE_RESOURCES_DEFAULT);
         listenPort = ConfigurationManager.getConfigInstance().getInt(CONTAINER_LISTEN_PORT, LISTEN_PORT_DEFAULT);
+        isResourcesIsolated = ConfigurationManager.getConfigInstance().getBoolean(NETFLIX_ADMIN_RESOURCES_ISOLATE, ISOLATE_RESOURCES_DEFAULT);
+    }
+
+    @Override
+    public boolean shouldIsolateResources() {
+        return isResourcesIsolated;
     }
 
     @Override

--- a/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
@@ -4,6 +4,7 @@ import com.google.inject.ImplementedBy;
 
 @ImplementedBy(AdminConfigImpl.class)
 public interface AdminContainerConfig {
+    boolean shouldIsolateResources();
     boolean shouldEnable();
     String templateResourceContext();
     String ajaxDataResourceContext();

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminPageRegistry.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminPageRegistry.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 
+@Singleton
 public class AdminPageRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(AdminPageRegistry.class);
     public final static String PROP_ID_ADMIN_PAGES_SCAN = "netflix.platform.admin.pages.packages";


### PR DESCRIPTION
AdminContainerConfig supports shouldIsolateResources(). It creates a separate root injector instead of a child injector to parent application.
Most applications won't need to use this knob. The default behavior is to integrate bindings from parent application injector so they are available in admin resources classes