### PR TITLE
404 on bad Viewable request

### DIFF
--- a/karyon2-admin-web/src/main/java/netflix/adminresources/pages/AdminPageResource.java
+++ b/karyon2-admin-web/src/main/java/netflix/adminresources/pages/AdminPageResource.java
@@ -73,7 +73,6 @@ public class AdminPageResource {
             }
             return new Viewable(adminPageRegistry.getPageInfo(view).getPageTemplate(), model);
         }
-        LOG.info("Can not find " + view);
         throw new WebApplicationException(Response.Status.NOT_FOUND);
     }
 

--- a/karyon2-admin-web/src/main/java/netflix/adminresources/pages/AdminPageResource.java
+++ b/karyon2-admin-web/src/main/java/netflix/adminresources/pages/AdminPageResource.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.PostConstruct;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -72,8 +73,8 @@ public class AdminPageResource {
             }
             return new Viewable(adminPageRegistry.getPageInfo(view).getPageTemplate(), model);
         }
-
-        return new Viewable("/webadmin/" + view + "/index.ftl", model);
+        LOG.info("Can not find " + view);
+        throw new WebApplicationException(Response.Status.NOT_FOUND);
     }
 
     @POST

--- a/karyon2-admin-web/src/test/java/netflix/adminresources/WebAdminTest.java
+++ b/karyon2-admin-web/src/test/java/netflix/adminresources/WebAdminTest.java
@@ -103,6 +103,15 @@ public class WebAdminTest {
     }
 
     @Test
+    public void testInvalidEndpoint() throws Exception {
+        final String localhostUrlBase = String.format("http://localhost:%d/", adminServerPort);
+        final HttpClient client = new DefaultHttpClient();
+        HttpGet badGet = new HttpGet(localhostUrlBase + "/admin/not-there");
+        final HttpResponse resp = client.execute(badGet);
+        assertEquals(404, resp.getStatusLine().getStatusCode());
+    }
+
+    @Test
     public void testMaskedResources() throws Exception {
         HttpClient client = new DefaultHttpClient();
         final String endPoint = String.format("http://localhost:%d/webadmin/archprops", adminServerPort);


### PR DESCRIPTION
For an invalid viewId - trying to render Viewable results into a 500 with a ton of error logging on service. More frequently it has been the case for /favicon requests that were reported. 
This code changes cleanly returns a 404 if viewId is determined to be invalid

Unit Test is added to cover this issue