### PR TITLE
3.x: fix content length

### DIFF
--- a/karyon3-admin-simple/src/main/java/com/netflix/karyon/admin/rest/AdminHttpHandler.java
+++ b/karyon3-admin-simple/src/main/java/com/netflix/karyon/admin/rest/AdminHttpHandler.java
@@ -1,6 +1,5 @@
 package com.netflix.karyon.admin.rest;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;


### PR DESCRIPTION
There were two cases where the content-length header would
be incorrect:

1. If multi-byte characters were used in the payload. It was
   returning the character length instead of the number of
   bytes.
2. If compression was used it was returning the size of the
   raw data rather than the compressed size.

This change also makes the charset for the output UTF-8 rather
than using whatever the default is for the jdk.

Quick verification was done on the command line for the compression
use-case to verify the content-length now matches expectations:

```
$ curl -vs 'http://localhost:8077/jars' 2>headers | wc -c; cat headers | grep -i content-length
   31192
< Content-length: 31192
$ curl -vs 'http://localhost:8077/jars' -H'Accept-Encoding:gzip' 2>headers | wc -c; cat headers | grep -i content-length
    2717
< Content-length: 2717
$ curl -vs 'http://localhost:8077/jars' -H'Accept-Encoding:gzip' 2>headers | gunzip -c | wc -c; cat headers | grep -i content-length
   31192
< Content-length: 2717
```