### PR TITLE
Additional filters in karyon2-admin container

### DIFF
--- a/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
@@ -7,11 +7,12 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Singleton;
 import javax.servlet.Filter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Singleton
 public class AdminConfigImpl implements AdminContainerConfig {
-    private Logger logger = LoggerFactory.getLogger(this.getClass());
+    private static final Logger logger = LoggerFactory.getLogger(AdminConfigImpl.class);
 
     public static final String NETFLIX_ADMIN_TEMPLATE_CONTEXT = "netflix.admin.template.context";
     public static final String TEMPLATE_CONTEXT_DEFAULT = "/admin";
@@ -101,14 +102,15 @@ public class AdminConfigImpl implements AdminContainerConfig {
     @Override
     public List<Filter> additionalFilters() {
         if (rootContextFilters.isEmpty()) {
-            new ArrayList<>();
+            return Collections.emptyList();
         }
 
         List<Filter> filters = new ArrayList<>();
         final String[] filterClasses = rootContextFilters.split(",");
         for (String filterClass : filterClasses) {
             try {
-                final Class<?> filterCls = Class.forName(filterClass);
+                getClass().getClassLoader();
+                final Class<?> filterCls = Class.forName(filterClass, false, getClass().getClassLoader());
                 if (Filter.class.isAssignableFrom(filterCls)) {
                     Filter filter = (Filter) filterCls.newInstance();
                     filters.add(filter);

--- a/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
@@ -34,8 +34,8 @@ public class AdminConfigImpl implements AdminContainerConfig {
     public static final String NETFLIX_ADMIN_RESOURCES_ISOLATE = "netflix.admin.resources.isolate";
     public static final boolean ISOLATE_RESOURCES_DEFAULT = false;
 
-    public static final String NETFLIX_ADMIN_ROOT_CTX_FILTERS = "netflix.admin.root.context.filters";
-    public static final String DEFAULT_ROOT_CONTEXT_FILTERS = "";
+    public static final String NETFLIX_ADMIN_CTX_FILTERS = "netflix.admin.additional.filters";
+    public static final String DEFAULT_CONTEXT_FILTERS = "";
 
 
     private final String templateResContext;
@@ -55,7 +55,7 @@ public class AdminConfigImpl implements AdminContainerConfig {
         viewableResources = ConfigurationManager.getConfigInstance().getString(JERSEY_VIEWABLE_RESOURCES, JERSEY_VIEWABLE_RESOURCES_DEFAULT);
         listenPort = ConfigurationManager.getConfigInstance().getInt(CONTAINER_LISTEN_PORT, LISTEN_PORT_DEFAULT);
         isResourcesIsolated = ConfigurationManager.getConfigInstance().getBoolean(NETFLIX_ADMIN_RESOURCES_ISOLATE, ISOLATE_RESOURCES_DEFAULT);
-        rootContextFilters = ConfigurationManager.getConfigInstance().getString(NETFLIX_ADMIN_ROOT_CTX_FILTERS, DEFAULT_ROOT_CONTEXT_FILTERS);
+        rootContextFilters = ConfigurationManager.getConfigInstance().getString(NETFLIX_ADMIN_CTX_FILTERS, DEFAULT_CONTEXT_FILTERS);
     }
 
     @Override

--- a/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
@@ -2,6 +2,9 @@ package netflix.admin;
 
 import com.google.inject.ImplementedBy;
 
+import javax.servlet.Filter;
+import java.util.List;
+
 @ImplementedBy(AdminConfigImpl.class)
 public interface AdminContainerConfig {
     boolean shouldIsolateResources();
@@ -12,4 +15,6 @@ public interface AdminContainerConfig {
     String jerseyViewableResourcePkgList();
     boolean shouldScanClassPathForPluginDiscovery();
     int listenPort();
+    List<Filter> additionalFilters();
+
 }

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -120,7 +120,6 @@ public class AdminResourcesContainer {
                 final Context rootHandler = new Context();
                 rootHandler.setContextPath("/");
                 rootHandler.addFilter(new FilterHolder(adminResourceInjector.getInstance(RedirectFilter.class)), "/*", Handler.DEFAULT);
-                applyAdditionalFilters(rootHandler, additionaFilters);
                 rootHandler.addServlet(new ServletHolder(new DefaultServlet()), "/*");
 
                 // admin page template resources

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.servlet.Filter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -118,6 +119,7 @@ public class AdminResourcesContainer {
                 final Context rootHandler = new Context();
                 rootHandler.setContextPath("/");
                 rootHandler.addFilter(new FilterHolder(adminResourceInjector.getInstance(RedirectFilter.class)), "/*", Handler.DEFAULT);
+                applyAdditionalFilters(rootHandler);
                 rootHandler.addServlet(new ServletHolder(new DefaultServlet()), "/*");
 
                 // admin page template resources
@@ -129,6 +131,7 @@ public class AdminResourcesContainer {
                 adminTemplatesResHandler.setSessionHandler(new SessionHandler());
                 adminTemplatesResHandler.addFilter(LoggingFilter.class, "/*", Handler.DEFAULT);
                 adminTemplatesResHandler.addFilter(new FilterHolder(adminResourceInjector.getInstance(RedirectFilter.class)), "/*", Handler.DEFAULT);
+                applyAdditionalFilters(adminTemplatesResHandler);
                 adminTemplatesResHandler.addFilter(new FilterHolder(arfTemplatesResources), "/*", Handler.DEFAULT);
                 adminTemplatesResHandler.addServlet(new ServletHolder(new DefaultServlet()), "/*");
 
@@ -140,6 +143,7 @@ public class AdminResourcesContainer {
                 final Context adminDataResHandler = new Context();
                 adminDataResHandler.setContextPath(adminContainerConfig.ajaxDataResourceContext());
                 adminDataResHandler.addFilter(new FilterHolder(adminResourceInjector.getInstance(RedirectFilter.class)), "/*", Handler.DEFAULT);
+                applyAdditionalFilters(adminDataResHandler);
                 adminDataResHandler.addFilter(new FilterHolder(arfDataResources), "/*", Handler.DEFAULT);
                 adminDataResHandler.addServlet(new ServletHolder(new DefaultServlet()), "/*");
 
@@ -220,6 +224,15 @@ public class AdminResourcesContainer {
 
     private boolean shouldShareResourcesWithParentInjector() {
         return appInjector != null && ! adminContainerConfig.shouldIsolateResources();
+    }
+
+    private void applyAdditionalFilters(final Context contextHandler) {
+        final List<Filter> rootFilters = adminContainerConfig.additionalFilters();
+        if (rootFilters != null && !rootFilters.isEmpty()) {
+            for(Filter f : rootFilters) {
+                contextHandler.addFilter(new FilterHolder(f), "/*", Handler.DEFAULT);
+            }
+        }
     }
 
     @PreDestroy

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -114,12 +114,13 @@ public class AdminResourcesContainer {
                 }
 
                 server = new Server(adminContainerConfig.listenPort());
+                final List<Filter> additionaFilters = adminContainerConfig.additionalFilters();
 
                 // redirect filter based on configurable RedirectRules
                 final Context rootHandler = new Context();
                 rootHandler.setContextPath("/");
                 rootHandler.addFilter(new FilterHolder(adminResourceInjector.getInstance(RedirectFilter.class)), "/*", Handler.DEFAULT);
-                applyAdditionalFilters(rootHandler);
+                applyAdditionalFilters(rootHandler, additionaFilters);
                 rootHandler.addServlet(new ServletHolder(new DefaultServlet()), "/*");
 
                 // admin page template resources
@@ -131,7 +132,7 @@ public class AdminResourcesContainer {
                 adminTemplatesResHandler.setSessionHandler(new SessionHandler());
                 adminTemplatesResHandler.addFilter(LoggingFilter.class, "/*", Handler.DEFAULT);
                 adminTemplatesResHandler.addFilter(new FilterHolder(adminResourceInjector.getInstance(RedirectFilter.class)), "/*", Handler.DEFAULT);
-                applyAdditionalFilters(adminTemplatesResHandler);
+                applyAdditionalFilters(adminTemplatesResHandler, additionaFilters);
                 adminTemplatesResHandler.addFilter(new FilterHolder(arfTemplatesResources), "/*", Handler.DEFAULT);
                 adminTemplatesResHandler.addServlet(new ServletHolder(new DefaultServlet()), "/*");
 
@@ -143,7 +144,7 @@ public class AdminResourcesContainer {
                 final Context adminDataResHandler = new Context();
                 adminDataResHandler.setContextPath(adminContainerConfig.ajaxDataResourceContext());
                 adminDataResHandler.addFilter(new FilterHolder(adminResourceInjector.getInstance(RedirectFilter.class)), "/*", Handler.DEFAULT);
-                applyAdditionalFilters(adminDataResHandler);
+                applyAdditionalFilters(adminDataResHandler, additionaFilters);
                 adminDataResHandler.addFilter(new FilterHolder(arfDataResources), "/*", Handler.DEFAULT);
                 adminDataResHandler.addServlet(new ServletHolder(new DefaultServlet()), "/*");
 
@@ -226,10 +227,9 @@ public class AdminResourcesContainer {
         return appInjector != null && ! adminContainerConfig.shouldIsolateResources();
     }
 
-    private void applyAdditionalFilters(final Context contextHandler) {
-        final List<Filter> rootFilters = adminContainerConfig.additionalFilters();
-        if (rootFilters != null && !rootFilters.isEmpty()) {
-            for(Filter f : rootFilters) {
+    private void applyAdditionalFilters(final Context contextHandler, List<Filter> additionalFilters) {
+        if (additionalFilters != null && !additionalFilters.isEmpty()) {
+            for(Filter f : additionalFilters) {
                 contextHandler.addFilter(new FilterHolder(f), "/*", Handler.DEFAULT);
             }
         }

--- a/karyon2-admin/src/test/java/netflix/adminresources/AdminResourceTest.java
+++ b/karyon2-admin/src/test/java/netflix/adminresources/AdminResourceTest.java
@@ -97,7 +97,7 @@ public class AdminResourceTest {
 
     @Test
     public void checkAuthFilter() throws Exception {
-        setConfig(AdminConfigImpl.NETFLIX_ADMIN_ROOT_CTX_FILTERS, "netflix.adminresources.AuthFilter");
+        setConfig(AdminConfigImpl.NETFLIX_ADMIN_CTX_FILTERS, "netflix.adminresources.AuthFilter");
         final int port = startServerAndGetListeningPort();
         HttpClient client = new DefaultHttpClient();
 
@@ -116,7 +116,7 @@ public class AdminResourceTest {
         assertEquals("admin resource ping resource failed.", 404, response.getStatusLine().getStatusCode());
 
         final AbstractConfiguration configInst = ConfigurationManager.getConfigInstance();
-        configInst.clearProperty(AdminConfigImpl.NETFLIX_ADMIN_ROOT_CTX_FILTERS);
+        configInst.clearProperty(AdminConfigImpl.NETFLIX_ADMIN_CTX_FILTERS);
     }
 
     @Test

--- a/karyon2-admin/src/test/java/netflix/adminresources/AuthFilter.java
+++ b/karyon2-admin/src/test/java/netflix/adminresources/AuthFilter.java
@@ -13,7 +13,7 @@ public class AuthFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         if (request instanceof HttpServletRequest) {
             String url = ((HttpServletRequest)request).getRequestURI();
-            if (url.startsWith("/main")) {
+            if (url.startsWith("/main") || url.startsWith("/auth")) {
                 ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
             }
             chain.doFilter(request, response);

--- a/karyon2-admin/src/test/java/netflix/adminresources/AuthFilter.java
+++ b/karyon2-admin/src/test/java/netflix/adminresources/AuthFilter.java
@@ -1,0 +1,27 @@
+package netflix.adminresources;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AuthFilter implements Filter {
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {}
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        if (request instanceof HttpServletRequest) {
+            String url = ((HttpServletRequest)request).getRequestURI();
+            if (url.startsWith("/main")) {
+                ((HttpServletResponse) response).sendError(HttpServletResponse.SC_FORBIDDEN);
+            }
+            chain.doFilter(request, response);
+        }
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}


### PR DESCRIPTION
config param to introduce additional filters to admin resources.
While it defaults to no different behavior than current state, it provides an extension point to provide extra tomcat filter behavior that is pluggable in karyon2-admin container