### PR TITLE
Add support for Governator's AutoBindSingleton

### DIFF
--- a/karyon3-core/src/main/java/com/netflix/karyon/Karyon.java
+++ b/karyon3-core/src/main/java/com/netflix/karyon/Karyon.java
@@ -258,7 +258,7 @@ public class Karyon {
                 apply((KaryonModule) Class.forName("com.netflix.karyon.archaius.ArchaiusKaryonModule").newInstance());
             }
             catch (ClassNotFoundException e) {
-                throw new RuntimeException("Unable to bootstrap using archaius. Either add a dependency on 'com.netflix.karyon:karyon3-archaius2' or disable the feature KaryonFeatures.USE_ARCHAIUS");
+                System.err.println("Unable to bootstrap using archaius. Either add a dependency on 'com.netflix.karyon:karyon3-archaius2' or disable the feature KaryonFeatures.USE_ARCHAIUS");
             } 
             catch (InstantiationException | IllegalAccessException e) {
                 throw new RuntimeException("Unable to bootstrap using archaius");

--- a/karyon3-core/src/main/java/com/netflix/karyon/governator/AutoBindModule.java
+++ b/karyon3-core/src/main/java/com/netflix/karyon/governator/AutoBindModule.java
@@ -42,7 +42,7 @@ import com.netflix.karyon.KaryonModule;
  *          .ignorePackages("com.example.ignore")
  *       )
  *       .start();
- * <code>
+ * </code>
  * @author elandau
  *
  */

--- a/karyon3-core/src/main/java/com/netflix/karyon/governator/AutoBindModule.java
+++ b/karyon3-core/src/main/java/com/netflix/karyon/governator/AutoBindModule.java
@@ -25,11 +25,24 @@ import com.netflix.karyon.KaryonModule;
  * Karyon.create()
  *       .apply(new AutoBindModule()
  *          .includePackages("com.example")
- *          .ignorePackages("com.example.ignore")
  *       )
  *       .start();
  * </code>
  * 
+ * Note that classpath scanning can be dangerous as it may pick up unwanted classes.  It is possible
+ * to ignore specific classes and packages from the classpath scanning result.  Ignore always takes
+ * Precedence over any classes under the included packages.  Package ignore is done using a prefix
+ * match so all subpackages will also be ignored.
+ * 
+ * <code>
+ * Karyon.create()
+ *       .apply(new AutoBindModule()
+ *          .includePackages("com.example")
+ *          .ignoreClasses("com.example.ignore.SomeClassToIgnore")
+ *          .ignorePackages("com.example.ignore")
+ *       )
+ *       .start();
+ * <code>
  * @author elandau
  *
  */
@@ -52,7 +65,7 @@ public class AutoBindModule extends AbstractKaryonModule {
     
     /**
      * Specify the class loader to use.  By default, Thread.currentThread().getContextClassLoader()
-     * will be sued.
+     * will be used.
      * 
      * @param loader
      */
@@ -62,7 +75,7 @@ public class AutoBindModule extends AbstractKaryonModule {
     }
     
     /**
-     * Specify class names to ignore
+     * Specify class names to ignore.  
      * @param classes
      */
     public KaryonModule ignoreClassNames(String ... classes) {
@@ -110,7 +123,7 @@ public class AutoBindModule extends AbstractKaryonModule {
     }
 
     /**
-     * Specify packages to ignore
+     * Specify packages to ignore.  Note that all sub-packages will be ignored as well.
      * @param packages
      */
     public KaryonModule ignorePackages(String ... packages) {
@@ -121,7 +134,7 @@ public class AutoBindModule extends AbstractKaryonModule {
     }
     
     /**
-     * Specify packages to ignore
+     * Specify packages to ignore.  Note that all sub-packages will be ignored as well.
      * @param packages
      */
     public KaryonModule ignorePackages(Collection<String> packages) {

--- a/karyon3-core/src/main/java/com/netflix/karyon/governator/AutoBindModule.java
+++ b/karyon3-core/src/main/java/com/netflix/karyon/governator/AutoBindModule.java
@@ -1,0 +1,197 @@
+package com.netflix.karyon.governator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.reflect.ClassPath;
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import com.netflix.governator.annotations.AutoBindSingleton;
+import com.netflix.karyon.AbstractKaryonModule;
+import com.netflix.karyon.KaryonModule;
+
+/**
+ * Backwards compatibility support for governator's AutoBindSingleton annotation. 
+ * 
+ * To enable,
+ * 
+ * <code>
+ * Karyon.create()
+ *       .apply(new AutoBindModule()
+ *          .includePackages("com.example")
+ *          .ignorePackages("com.example.ignore")
+ *       )
+ *       .start();
+ * </code>
+ * 
+ * @author elandau
+ *
+ */
+public class AutoBindModule extends AbstractKaryonModule {
+    private List<String> packages = Lists.newArrayList();
+    private ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    private Set<String> classesToIgnore = new HashSet<>();
+    private Set<String> packagesToIgnore = new HashSet<>();
+    
+    /**
+     * Specify packages to include in classpath scanning
+     * @param packages
+     */
+    public AutoBindModule includePackages(String... packages) {
+        if (packages != null) {
+            this.packages.addAll(Arrays.asList(packages));
+        }
+        return this;
+    }
+    
+    /**
+     * Specify the class loader to use.  By default, Thread.currentThread().getContextClassLoader()
+     * will be sued.
+     * 
+     * @param loader
+     */
+    public AutoBindModule withClassLoader(ClassLoader loader) {
+        this.classLoader = loader;
+        return this;
+    }
+    
+    /**
+     * Specify class names to ignore
+     * @param classes
+     */
+    public KaryonModule ignoreClassNames(String ... classes) {
+        if (classes != null) {
+            return ignoreClassNames(Arrays.asList(classes));
+        }
+        return this;
+    }
+    
+    /**
+     * Specify class names to ignore
+     * @param classes
+     */
+    public KaryonModule ignoreClassNames(Collection<String> classes) {
+        if (classes != null) {
+            for (String cls : classes) {
+                classesToIgnore.add(cls);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Specify class types to ignore
+     * @param classes
+     */
+    public KaryonModule ignoreClasses(Class<?> ... classes) {
+        if (classes != null) {
+            return ignoreClasses(Arrays.asList(classes));
+        }
+        return this;
+    }
+    
+    /**
+     * Specify class types to ignore
+     * @param classes
+     */
+    public KaryonModule ignoreClasses(Collection<Class<?>> classes) {
+        if (classes != null) {
+            for (Class<?> cls : classes) {
+                classesToIgnore.add(cls.getName());
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Specify packages to ignore
+     * @param packages
+     */
+    public KaryonModule ignorePackages(String ... packages) {
+        if (packages != null) {
+            return ignorePackages(Arrays.asList(packages));
+        }
+        return this;
+    }
+    
+    /**
+     * Specify packages to ignore
+     * @param packages
+     */
+    public KaryonModule ignorePackages(Collection<String> packages) {
+        if (packages != null) {
+            for (String pkg : packages) {
+                if (pkg.endsWith(".")) 
+                    packagesToIgnore.add(pkg);
+                else 
+                    packagesToIgnore.add(pkg + ".");
+            }
+        }
+        return this;
+    }
+
+    private boolean shouldIncludeClass(ClassPath.ClassInfo info) {
+        // Include Modules that have at least on Conditional
+        if (classesToIgnore.contains(info.getName())) {
+            return false;
+        }
+        for (String packageToIgnore : packagesToIgnore) {
+            if (info.getName().startsWith(packageToIgnore)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    protected void configure() {
+        ClassPath classpath;
+        final List<Module> modules = new ArrayList<>();
+        final List<Class<?>> singletons = new ArrayList<>();
+        for (String pkg : packages) {
+            try {
+                classpath = ClassPath.from(classLoader);
+                for (ClassPath.ClassInfo classInfo : classpath.getTopLevelClassesRecursive(pkg)) {
+                    try {
+                        Class<?> cls = Class.forName(classInfo.getName(), false, classLoader);
+                        AutoBindSingleton abs = cls.getAnnotation(AutoBindSingleton.class);
+                        if (abs != null & shouldIncludeClass(classInfo)) {
+                            if (Module.class.isAssignableFrom(cls)) {
+                                modules.add((Module) cls.newInstance());
+                            }
+                            else {
+                                singletons.add(cls);
+                            }
+                        }
+                    }
+                    catch (Exception e) {
+                        throw new RuntimeException("Failed to instantiate module '" + classInfo.getName() + "'", e);
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to scan root package '" + pkg + "'", e);
+            }
+        }
+        
+        addModules(new AbstractModule() {
+            @Override
+            protected void configure() {
+                install(Modules.combine(modules));
+                for (Class<?> singleton : singletons) {
+                    bind(singleton).asEagerSingleton();
+                }
+            }
+            
+            @Override
+            public String toString() {
+                return "AutoBindSingletonModule[]";
+            }
+        });
+    }
+}

--- a/karyon3-core/src/test/java/com/netflix/karyon/KaryonTest.java
+++ b/karyon3-core/src/test/java/com/netflix/karyon/KaryonTest.java
@@ -3,11 +3,6 @@ package com.netflix.karyon;
 import org.junit.Test;
 
 public class KaryonTest {
-    @Test(expected=RuntimeException.class)
-    public void testDefault() {
-        Karyon.create().start();
-    }
-    
     @Test
     public void testDefaultWithoutArchaius() {
         Karyon

--- a/karyon3-junit/src/test/java/com/netflix/karyon/governator/AutoBindModuleTest.java
+++ b/karyon3-junit/src/test/java/com/netflix/karyon/governator/AutoBindModuleTest.java
@@ -1,0 +1,52 @@
+package com.netflix.karyon.governator;
+
+import junit.framework.Assert;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.netflix.karyon.governator.ignore.TestAbsToIgnore;
+import com.netflix.karyon.junit.KaryonRule;
+
+public class AutoBindModuleTest {
+    @Rule
+    public KaryonRule karyon = new KaryonRule(this);
+    
+    @Test
+    public void shouldAddAllAbs() {
+        karyon
+            .apply(new AutoBindModule()
+                .includePackages("com.netflix.karyon.governator"))
+            .start();
+        
+        Assert.assertTrue(karyon.didInject(TestAbs.class));
+        Assert.assertTrue(karyon.didInject(TestAbsFromModule.class));
+        Assert.assertTrue(karyon.didInject(TestAbsToIgnore.class));
+    }
+    
+    @Test
+    public void shouldIgnoreClass() {
+        karyon
+            .apply(new AutoBindModule()
+                .includePackages("com.netflix.karyon.governator")
+                .ignoreClasses(TestAbsToIgnore.class))
+            .start();
+        
+        Assert.assertTrue(karyon.didInject(TestAbs.class));
+        Assert.assertTrue(karyon.didInject(TestAbsFromModule.class));
+        Assert.assertFalse(karyon.didInject(TestAbsToIgnore.class));
+    }
+    
+    @Test
+    public void shouldIgnorePackage() {
+        karyon
+            .apply(new AutoBindModule()
+                .includePackages("com.netflix.karyon.governator")
+                .ignorePackages("com.netflix.karyon.governator.ignore"))
+            .start();
+        
+        Assert.assertTrue(karyon.didInject(TestAbs.class));
+        Assert.assertTrue(karyon.didInject(TestAbsFromModule.class));
+        Assert.assertFalse(karyon.didInject(TestAbsToIgnore.class));
+    }
+}

--- a/karyon3-junit/src/test/java/com/netflix/karyon/governator/TestAbs.java
+++ b/karyon3-junit/src/test/java/com/netflix/karyon/governator/TestAbs.java
@@ -1,0 +1,7 @@
+package com.netflix.karyon.governator;
+
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+@AutoBindSingleton
+public class TestAbs {
+}

--- a/karyon3-junit/src/test/java/com/netflix/karyon/governator/TestAbsFromModule.java
+++ b/karyon3-junit/src/test/java/com/netflix/karyon/governator/TestAbsFromModule.java
@@ -1,0 +1,5 @@
+package com.netflix.karyon.governator;
+
+public class TestAbsFromModule {
+
+}

--- a/karyon3-junit/src/test/java/com/netflix/karyon/governator/TestAbsModule.java
+++ b/karyon3-junit/src/test/java/com/netflix/karyon/governator/TestAbsModule.java
@@ -1,0 +1,12 @@
+package com.netflix.karyon.governator;
+
+import com.google.inject.AbstractModule;
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+@AutoBindSingleton
+public class TestAbsModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(TestAbsFromModule.class).asEagerSingleton();
+    }
+}

--- a/karyon3-junit/src/test/java/com/netflix/karyon/governator/ignore/TestAbsToIgnore.java
+++ b/karyon3-junit/src/test/java/com/netflix/karyon/governator/ignore/TestAbsToIgnore.java
@@ -1,0 +1,8 @@
+package com.netflix.karyon.governator.ignore;
+
+import com.netflix.governator.annotations.AutoBindSingleton;
+
+@AutoBindSingleton
+public class TestAbsToIgnore {
+
+}


### PR DESCRIPTION
Support for Governator's @AutoBindSingleton for both classes and modules may be added as an add-on,

```java
Karyon.create()
       .apply(new AutoBindModule()
          .includePackages("com.example")
          .ignorePackages("com.example.ignore")
       )
       .start();
```