### PR TITLE
add file name to thread stack trace

### DIFF
--- a/karyon3-core/src/main/java/com/netflix/karyon/admin/ThreadsAdminResource.java
+++ b/karyon3-core/src/main/java/com/netflix/karyon/admin/ThreadsAdminResource.java
@@ -42,7 +42,7 @@ public class ThreadsAdminResource {
                     .stream().map(
                         (e) ->         e.getClassName() 
                                + "#" + e.getMethodName() 
-                               + ":" + e.getLineNumber())
+                               + "(" + e.getFileName() + ":" + e.getLineNumber() + ")")
                    .collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
The goal is to format the stack traces from the threads
admin resource so they can be copy and pasted into common
tools for analyzing them and browsing the code. This change
adds the the file name and formats similar to jstack output.