### PR TITLE
Dynamic Log4J2 log levels

### DIFF
--- a/karyon3-archaius2/src/main/java/com/netflix/karyon/archaius/ArchaiusKaryonModule.java
+++ b/karyon3-archaius2/src/main/java/com/netflix/karyon/archaius/ArchaiusKaryonModule.java
@@ -137,7 +137,7 @@ public class ArchaiusKaryonModule extends AbstractKaryonModule {
             if (appName != null) {
                 props.put(ServerContext.APP_ID, appName);
             }
-            else {
+            else if (getKaryon().getApplicationName() != null) {
                 props.put(ServerContext.APP_ID, getKaryon().getApplicationName());
             }
             

--- a/karyon3-archaius2/src/main/java/com/netflix/karyon/archaius/admin/ArchaiusPropResource.java
+++ b/karyon3-archaius2/src/main/java/com/netflix/karyon/archaius/admin/ArchaiusPropResource.java
@@ -37,7 +37,12 @@ public class ArchaiusPropResource {
         while (iter.hasNext()) {
             String key = iter.next();
             if (regex == null || key.matches(regex)) {
-                props.put(key, (String) config.getString(key, "****"));
+                try {
+                    props.put(key, (String) config.getString(key, "****"));
+                }
+                catch (Exception e) {
+                    props.put(key, "*** ERROR PARSING PROPERTY : " + e.getMessage());
+                }
             }
         }
         return new PropsModel(props);

--- a/karyon3-core/src/main/java/com/netflix/karyon/Karyon.java
+++ b/karyon3-core/src/main/java/com/netflix/karyon/Karyon.java
@@ -65,8 +65,6 @@ import com.netflix.karyon.spi.ModuleListTransformer;
 public class Karyon {
     private static final String KARYON_PROFILES = "karyon.profiles";
     
-    private static final String DEFAULT_APPLICATION_NAME = "KaryonApplication";
-    
     protected final String                applicationName;
     protected PropertySource              propertySource    = DefaultPropertySource.INSTANCE;
     protected Set<String>                 profiles          = new LinkedHashSet<>();
@@ -83,6 +81,11 @@ public class Karyon {
     static {
         System.setProperty("archaius.default.configuration.class",      "com.netflix.archaius.bridge.StaticAbstractConfiguration");
         System.setProperty("archaius.default.deploymentContext.class",  "com.netflix.archaius.bridge.StaticDeploymentContext");
+    }
+    
+    @Deprecated
+    private Karyon() {
+        this(null);
     }
     
     protected Karyon(String applicationName) {
@@ -374,7 +377,7 @@ public class Karyon {
      */
     @Deprecated
     public static Karyon create() {
-        return new Karyon(DEFAULT_APPLICATION_NAME);
+        return new Karyon();
     }
     
     /**
@@ -382,7 +385,7 @@ public class Karyon {
      */
     @Deprecated
     public static Karyon create(Module ... modules) {
-        return new Karyon(DEFAULT_APPLICATION_NAME).addModules(modules);
+        return new Karyon().addModules(modules);
     }
     
     /**
@@ -390,7 +393,7 @@ public class Karyon {
      */
     @Deprecated
     public static Karyon from(KaryonModule ... modules) {
-        Karyon karyon = new Karyon(DEFAULT_APPLICATION_NAME);
+        Karyon karyon = new Karyon();
         if (modules != null) {
             for (KaryonModule module : modules) {
                 karyon.apply(module);

--- a/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
+++ b/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
@@ -1,7 +1,9 @@
 package com.netflix.karyon.log4j;
 
 import java.io.Serializable;
+import java.nio.charset.Charset;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -13,33 +15,50 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.AbstractConfiguration;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 
-import com.google.common.base.Charsets;
-import com.netflix.archaius.Config;
+import com.netflix.archaius.ConfigProxyFactory;
+import com.netflix.archaius.annotations.DefaultValue;
 
 @Singleton
 public class ConsoleAppenderConfigurator implements Log4jConfigurator {
-    private static final String PROP_LOG4J_PATTERN = "log4j.appender.Console.pattern";
-    
-    private static final String DEFAULT_PATTERN = "%d{HH:mm:ss,SSS} [%t] %-5p %c %x %m %n";
+    public static interface AppenderConfig {
+        @DefaultValue("%d{HH:mm:ss,SSS} [%t] %-5p %c %x %m %n")
+        String getPattern();
+        
+        @DefaultValue("UTF-8")
+        String getCharset();
+        
+        @DefaultValue("true")
+        Boolean getAlwaysWriteExceptions();
 
-    private final Config _config;
+        @DefaultValue("false")
+        Boolean getNoConsoleNoAnsi();
+
+        @Nullable
+        String getHeader();
+        
+        @Nullable
+        String getFooter();
+    }
+    
+    private final AppenderConfig _config;
     
     @Inject
-    public ConsoleAppenderConfigurator(Config config) {
-        this._config = config;
+    public ConsoleAppenderConfigurator(ConfigProxyFactory factory) {
+        this._config = factory.newProxy(AppenderConfig.class, "log4j.appender.Console");
     }
     
     @Override
     public void doConfigure(AbstractConfiguration config) {
 
-        Layout<? extends Serializable> layout = PatternLayout.createLayout(_config.getString(PROP_LOG4J_PATTERN, DEFAULT_PATTERN), // pattern
+        Layout<? extends Serializable> layout = PatternLayout.createLayout(
+                _config.getPattern(), // pattern
                 config, // config
                 null,   // replace
-                Charsets.UTF_8, // charset
-                true,   // alwaysWriteExceptions
-                false,  // noConsoleNoAnsi
-                null,   // header
-                null);  // footer
+                Charset.forName(_config.getCharset()), // charset
+                _config.getAlwaysWriteExceptions(),   // alwaysWriteExceptions
+                _config.getNoConsoleNoAnsi(),  // noConsoleNoAnsi
+                _config.getHeader(),   // header
+                _config.getFooter());  // footer
 
         // Add the Console appender
         Appender appender;

--- a/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
+++ b/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
@@ -18,7 +18,7 @@ import com.netflix.archaius.Config;
 
 @Singleton
 public class ConsoleAppenderConfigurator implements Log4jConfigurator {
-    private static final String PROP_LOG4J_PATTERN = "karyon.log4j.pattern";
+    private static final String PROP_LOG4J_PATTERN = "karyon.log4j.appender.Console.pattern";
     
     private static final String DEFAULT_PATTERN = "%d{HH:mm:ss,SSS} [%t] %-5p %c %x %m %n";
 

--- a/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
+++ b/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
@@ -2,6 +2,7 @@ package com.netflix.karyon.log4j;
 
 import java.io.Serializable;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.logging.log4j.Level;
@@ -13,21 +14,32 @@ import org.apache.logging.log4j.core.config.AbstractConfiguration;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 
 import com.google.common.base.Charsets;
+import com.netflix.archaius.Config;
 
 @Singleton
 public class ConsoleAppenderConfigurator implements Log4jConfigurator {
+    private static final String PROP_LOG4J_PATTERN = "karyon.log4j.pattern";
+    
+    private static final String DEFAULT_PATTERN = "%d{HH:mm:ss,SSS} [%t] %-5p %c %x %m %n";
 
+    private final Config _config;
+    
+    @Inject
+    public ConsoleAppenderConfigurator(Config config) {
+        this._config = config;
+    }
+    
     @Override
     public void doConfigure(AbstractConfiguration config) {
 
-        Layout<? extends Serializable> layout = PatternLayout.createLayout("%d{HH:mm:ss,SSS} [%t] %-5p %c %x %m %n", // pattern
+        Layout<? extends Serializable> layout = PatternLayout.createLayout(_config.getString(PROP_LOG4J_PATTERN, DEFAULT_PATTERN), // pattern
                 config, // config
-                null, // replace
+                null,   // replace
                 Charsets.UTF_8, // charset
-                true, // alwaysWriteExceptions
-                false, // noConsoleNoAnsi
-                null, // header
-                null); // footer
+                true,   // alwaysWriteExceptions
+                false,  // noConsoleNoAnsi
+                null,   // header
+                null);  // footer
 
         // Add the Console appender
         Appender appender;

--- a/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
+++ b/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
@@ -38,6 +38,16 @@ public class ConsoleAppenderConfigurator implements Log4jConfigurator {
         
         @Nullable
         String getFooter();
+        
+        @DefaultValue("INFO")
+        String getLevel();
+        
+        @DefaultValue("false")
+        Boolean getFollow();
+        
+        @DefaultValue("true")
+        Boolean getIgnore();
+
     }
     
     private final AppenderConfig _config;
@@ -62,9 +72,9 @@ public class ConsoleAppenderConfigurator implements Log4jConfigurator {
 
         // Add the Console appender
         Appender appender;
-        appender = ConsoleAppender.createAppender(layout, null, null, "Console", null, null);
+        appender = ConsoleAppender.createAppender(layout, null, null, "Console", _config.getFollow().toString(), _config.getIgnore().toString());
         appender.start();
-        config.getRootLogger().addAppender(appender, Level.INFO, null);
+        config.getRootLogger().addAppender(appender, Level.valueOf(_config.getLevel()), null);
     }
 
 }

--- a/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
+++ b/karyon3-log4j2/src/main/java/com/netflix/karyon/log4j/ConsoleAppenderConfigurator.java
@@ -18,7 +18,7 @@ import com.netflix.archaius.Config;
 
 @Singleton
 public class ConsoleAppenderConfigurator implements Log4jConfigurator {
-    private static final String PROP_LOG4J_PATTERN = "karyon.log4j.appender.Console.pattern";
+    private static final String PROP_LOG4J_PATTERN = "log4j.appender.Console.pattern";
     
     private static final String DEFAULT_PATTERN = "%d{HH:mm:ss,SSS} [%t] %-5p %c %x %m %n";
 

--- a/karyon3-log4j2/src/main/java/org/apache/logging/log4j/core/ConfigListeners.java
+++ b/karyon3-log4j2/src/main/java/org/apache/logging/log4j/core/ConfigListeners.java
@@ -1,0 +1,38 @@
+package org.apache.logging.log4j.core;
+
+import java.util.function.Consumer;
+
+import com.netflix.archaius.Config;
+import com.netflix.archaius.ConfigListener;
+
+/**
+ * Utility class to simplify creating ConfigListener.
+ * 
+ * TODO: Move this archaius
+ */
+final class ConfigListeners {
+    static ConfigListener any(Consumer<Config> consumer) {
+        return new ConfigListener() {
+            @Override
+            public void onConfigAdded(Config config) {
+                consumer.accept(config);
+            }
+
+            @Override
+            public void onConfigRemoved(Config config) {
+                onConfigAdded(config);
+            }
+
+            @Override
+            public void onConfigUpdated(Config config) {
+                onConfigAdded(config);
+            }
+
+            @Override
+            public void onError(Throwable error, Config config) {
+                if (config != null)
+                    onConfigAdded(config);
+            }
+        };
+    }
+}

--- a/karyon3-log4j2/src/test/java/com/netflix/karyon/TestDynamicLogLevels.java
+++ b/karyon3-log4j2/src/test/java/com/netflix/karyon/TestDynamicLogLevels.java
@@ -1,0 +1,108 @@
+package com.netflix.karyon;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import junit.framework.Assert;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Log4jConfigurator;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.AbstractConfiguration;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.multibindings.Multibinder;
+import com.netflix.archaius.config.MapConfig;
+import com.netflix.archaius.config.SettableConfig;
+import com.netflix.archaius.exceptions.ConfigException;
+import com.netflix.archaius.inject.RuntimeLayer;
+import com.netflix.karyon.archaius.ArchaiusKaryonModule;
+import com.netflix.karyon.log4j.ArchaiusLog4J2ConfigurationModule;
+
+public class TestDynamicLogLevels {
+    @Singleton
+    public static class TestAppender extends AbstractAppender {
+        private static final long serialVersionUID = 1L;
+        private volatile String lastEvent;
+        
+        protected TestAppender() {
+            super("test", null, null);
+            System.out.println("***** TestAppender()");
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            lastEvent = event.getMessage().getFormattedMessage();
+        }
+        
+        public String getLastEvent() {
+            return lastEvent;
+        }
+    }
+    
+    @Singleton
+    public static class TestConfigurator implements Log4jConfigurator {
+        private TestAppender appender;
+        
+        @Inject
+        public TestConfigurator(TestAppender appender) {
+            this.appender = appender;
+        }
+        
+        @Override
+        public void doConfigure(AbstractConfiguration config) {
+            appender.start();
+            config.getRootLogger().addAppender(appender, Level.INFO, null);
+            config.addAppender(this.appender);
+        }
+    }
+    
+    @Test
+    public void testDynamicConfigurationChange() throws ConfigException, InterruptedException {
+        Injector injector = Karyon.forApplication("test")
+            .apply(new ArchaiusKaryonModule()
+                .withRuntimeOverrides(MapConfig.builder()
+                    .put("log4j.logger.com.netflix.karyon", "WARN")
+                    .build()))
+            .addModules(
+                new ArchaiusLog4J2ConfigurationModule(),
+                new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        Multibinder<Log4jConfigurator> appenderBinder = Multibinder.newSetBinder(binder(), Log4jConfigurator.class);
+                        appenderBinder.addBinding().to(TestConfigurator.class);
+                    }
+                }
+            )
+            .start();
+        
+        Logger log = LoggerFactory.getLogger(TestDynamicLogLevels.class);
+        
+        SettableConfig config = injector.getInstance(Key.get(SettableConfig.class, RuntimeLayer.class));
+        TestAppender appender = injector.getInstance(TestAppender.class);
+        
+        log.warn("test_warn");
+        TimeUnit.MILLISECONDS.sleep(50);
+        Assert.assertEquals("test_warn", appender.getLastEvent());
+        
+        log.info("test_info1");
+        TimeUnit.MILLISECONDS.sleep(50);
+        Assert.assertEquals("test_warn", appender.getLastEvent());
+        
+        config.setProperty("log4j.logger.com.netflix.karyon", "INFO");
+        TimeUnit.MILLISECONDS.sleep(50);
+        log.info("test_info2");
+        TimeUnit.MILLISECONDS.sleep(50);
+        Assert.assertEquals("test_info2", appender.getLastEvent());
+
+        
+    }
+}


### PR DESCRIPTION
* Make ConsoleAppenderConfigurator configurable via 'karyon.log4j' prefix
* Dynamically update log levels whenever the configuration changes

Misc changes,
* Don't completely fail returning properties in ArchaiusPropResource.  Instead report the errors as the property value
* Allow default application name to be empty
