### PR TITLE
Proper implementation of ConditionalOnMissingBinding

### DIFF
--- a/karyon3-core/src/main/java/com/netflix/karyon/KaryonAutoContext.java
+++ b/karyon3-core/src/main/java/com/netflix/karyon/KaryonAutoContext.java
@@ -1,5 +1,6 @@
 package com.netflix.karyon;
 
+import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Set;
 
@@ -26,6 +27,27 @@ public interface KaryonAutoContext {
      * @return Return true if a binding exists for a key
      */
     <T> boolean hasBinding(Class<T> type);
+
+    /**
+     * 
+     * @param type
+     * @param qualifier
+     * @return Return true if a binding exists for a type and qualifier
+     */
+    <T> boolean hasBinding(Class<T> type, Class<? extends Annotation> qualifier);
+
+    /**
+     * @param type
+     * @return Return true if there exists an injection point for the specified type
+     */
+    <T> boolean hasInjectionPoint(Class<T> type);
+
+    /**
+     * @param type
+     * @param qualifier
+     * @return Return true if there exists an injection point for the specified type and qualifier
+     */
+    <T> boolean hasInjectionPoint(Class<T> type, Class<? extends Annotation> qualifier);
 
     /**
      * Get all elements that are part of the core modules

--- a/karyon3-core/src/main/java/com/netflix/karyon/conditional/ConditionalOnMissingBinding.java
+++ b/karyon3-core/src/main/java/com/netflix/karyon/conditional/ConditionalOnMissingBinding.java
@@ -13,5 +13,6 @@ import com.netflix.karyon.conditional.impl.OnMissingBindingCondition;
 @Documented
 @Conditional(OnMissingBindingCondition.class)
 public @interface ConditionalOnMissingBinding {
-    String[] value();
+    String value();
+    String qualifier() default "";
 }

--- a/karyon3-core/src/test/java/com/netflix/karyon/conditional/ConditionalOnMissingBindingTest.java
+++ b/karyon3-core/src/test/java/com/netflix/karyon/conditional/ConditionalOnMissingBindingTest.java
@@ -1,0 +1,57 @@
+package com.netflix.karyon.conditional;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.CreationException;
+import com.google.inject.Guice;
+import com.netflix.karyon.Karyon;
+import com.netflix.karyon.ModuleListProviders;
+
+public class ConditionalOnMissingBindingTest {
+    
+    @ConditionalOnMissingBinding("com.netflix.karyon.conditional.ConditionalOnMissingBindingTest.DepA")
+    public static class DepAImplModule extends AbstractModule {
+        @Override
+        protected void configure() {
+        }
+    }
+    
+    public static interface DepA {
+    }
+    
+    public static class DepAImpl implements DepA {
+    }
+    
+    @Singleton
+    public static class Foo {
+        @Inject
+        Foo(DepA a) {
+        }
+    }
+    
+    @Test(expected=CreationException.class)
+    public void testNoConditional() {
+        Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Foo.class).asEagerSingleton();
+            }
+        });
+    }
+    
+    @Test
+    public void testWithConditional() {
+        Karyon.forApplication("test")
+            .addModules(new AbstractModule() {
+                @Override
+                protected void configure() {
+                    bind(Foo.class).asEagerSingleton();
+                }
+            })
+            .addAutoModuleListProvider(ModuleListProviders.forModules(new DepAImplModule()));
+    }
+}


### PR DESCRIPTION
Modify OnMissingBindingCondition to be true IFF an injection point exists but no binding is provided in a module.

ConditionalOnMissingBinding should be used in combination with conditionals such as ConditionalOnProfile instead of ConditionalOnModule to provide a binding if and only if one wasn't already explicitly specified.  This results in an easier to reason behavior when a binding is provided.