### PR TITLE
close response output stream on 404 handler

### DIFF
--- a/karyon3-admin-simple/src/main/java/com/netflix/karyon/admin/rest/NotFoundHttpHandler.java
+++ b/karyon3-admin-simple/src/main/java/com/netflix/karyon/admin/rest/NotFoundHttpHandler.java
@@ -1,6 +1,7 @@
 package com.netflix.karyon.admin.rest;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 import com.google.common.base.Charsets;
 import com.sun.net.httpserver.HttpExchange;
@@ -9,8 +10,11 @@ import com.sun.net.httpserver.HttpHandler;
 public class NotFoundHttpHandler implements HttpHandler {
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.getResponseHeaders().set("Content-Type", "text/plain");
         exchange.sendResponseHeaders(404, 0);
-        exchange.getResponseBody().write("not found".getBytes(Charsets.UTF_8));
+        try (OutputStream out = exchange.getResponseBody()) {
+            String msg = "Resource '" + exchange.getRequestURI().getPath() + "' not found.\n";
+            out.write(msg.getBytes(Charsets.UTF_8));
+        }
     }
 }


### PR DESCRIPTION
This change has two fixes for the default fallback handler
used with the simple admin:

1. Close the stream. Before the client would hang and eventually
   timeout causing connections in a close_wait state to accumulate
   on the server.
2. Fix the content type. The response payload isn't actually json.

I tried this change on one of our clusters and no longer see the
number of connections in close_wait growing:

![close_wait](https://cloud.githubusercontent.com/assets/1289028/11890415/fce1172a-a508-11e5-8408-576cab65653e.png)
