### PR TITLE
Deprecate main entry point classes of Karyon2

### DIFF
--- a/karyon2-governator/src/main/java/netflix/karyon/AbstractKaryonServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/AbstractKaryonServer.java
@@ -8,7 +8,9 @@ import java.util.Arrays;
 
 /**
  * @author Nitesh Kant
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 abstract class AbstractKaryonServer implements KaryonServer {
 
     protected final BootstrapModule[] bootstrapModules;

--- a/karyon2-governator/src/main/java/netflix/karyon/AbstractKaryonServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/AbstractKaryonServer.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 
 /**
  * @author Nitesh Kant
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 abstract class AbstractKaryonServer implements KaryonServer {

--- a/karyon2-governator/src/main/java/netflix/karyon/Karyon.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/Karyon.java
@@ -25,7 +25,9 @@ import rx.Observable;
  * {@link Bootstrap} annotations.
  *
  * @author Nitesh Kant
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 public final class Karyon {
 
     private Karyon() {

--- a/karyon2-governator/src/main/java/netflix/karyon/Karyon.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/Karyon.java
@@ -25,7 +25,7 @@ import rx.Observable;
  * {@link Bootstrap} annotations.
  *
  * @author Nitesh Kant
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 public final class Karyon {

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonBootstrap.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonBootstrap.java
@@ -12,11 +12,13 @@ import java.lang.annotation.Target;
 
 /**
  * @author Nitesh Kant
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Bootstrap(bootstrap = KaryonBootstrapModule.class)
+@Deprecated
 public @interface KaryonBootstrap {
 
     String name();

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonBootstrap.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonBootstrap.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
 
 /**
  * @author Nitesh Kant
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonBootstrapModule.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonBootstrapModule.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
  * A guice module that defines all bindings required by karyon. Applications must use this to bootstrap karyon.
  *
  * @author Nitesh Kant
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 public class KaryonBootstrapModule implements BootstrapModule {

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonBootstrapModule.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonBootstrapModule.java
@@ -15,7 +15,9 @@ import javax.inject.Inject;
  * A guice module that defines all bindings required by karyon. Applications must use this to bootstrap karyon.
  *
  * @author Nitesh Kant
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 public class KaryonBootstrapModule implements BootstrapModule {
 
     private final Class<? extends HealthCheckHandler> healthcheckHandlerClass;

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonRunner.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonRunner.java
@@ -22,7 +22,9 @@ import org.slf4j.LoggerFactory;
  * If you are bootstrapping karyon programmatically, it is better to use {@code Karyon} directly.
  *
  * @author Nitesh Kant
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 public class KaryonRunner {
 
     private static final Logger logger = LoggerFactory.getLogger(KaryonRunner.class);

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonRunner.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonRunner.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
  * If you are bootstrapping karyon programmatically, it is better to use {@code Karyon} directly.
  *
  * @author Nitesh Kant
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 public class KaryonRunner {

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonServer.java
@@ -4,7 +4,7 @@ package netflix.karyon;
  * A logical abstraction to manage the lifecycle of a karyon based application.
  * This does not define any contracts of handling and processing requests, those should all be defined by means of
  * modules.
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 public interface KaryonServer {

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonServer.java
@@ -4,7 +4,9 @@ package netflix.karyon;
  * A logical abstraction to manage the lifecycle of a karyon based application.
  * This does not define any contracts of handling and processing requests, those should all be defined by means of
  * modules.
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 public interface KaryonServer {
 
     /**

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonServerBackedServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonServerBackedServer.java
@@ -6,7 +6,7 @@ import com.netflix.governator.guice.BootstrapModule;
  * An implementation of {@link KaryonServer} which wraps an existing {@link KaryonServer}.
  *
  * @author Nitesh Kant
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 class KaryonServerBackedServer implements KaryonServer {

--- a/karyon2-governator/src/main/java/netflix/karyon/KaryonServerBackedServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/KaryonServerBackedServer.java
@@ -6,7 +6,9 @@ import com.netflix.governator.guice.BootstrapModule;
  * An implementation of {@link KaryonServer} which wraps an existing {@link KaryonServer}.
  *
  * @author Nitesh Kant
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 class KaryonServerBackedServer implements KaryonServer {
 
     private final AbstractKaryonServer delegate;

--- a/karyon2-governator/src/main/java/netflix/karyon/MainClassBasedServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/MainClassBasedServer.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CountDownLatch;
 
 /**
  * @author Nitesh Kant
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 class MainClassBasedServer extends AbstractKaryonServer {

--- a/karyon2-governator/src/main/java/netflix/karyon/MainClassBasedServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/MainClassBasedServer.java
@@ -10,7 +10,9 @@ import java.util.concurrent.CountDownLatch;
 
 /**
  * @author Nitesh Kant
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 class MainClassBasedServer extends AbstractKaryonServer {
 
     private static final Logger logger = LoggerFactory.getLogger(MainClassBasedServer.class);

--- a/karyon2-governator/src/main/java/netflix/karyon/RxNettyServerBackedServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/RxNettyServerBackedServer.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
  * An implementation of {@link KaryonServer} which wraps an RxNetty's server.
  *
  * @author Nitesh Kant
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 class RxNettyServerBackedServer extends MainClassBasedServer {

--- a/karyon2-governator/src/main/java/netflix/karyon/RxNettyServerBackedServer.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/RxNettyServerBackedServer.java
@@ -9,7 +9,9 @@ import org.slf4j.LoggerFactory;
  * An implementation of {@link KaryonServer} which wraps an RxNetty's server.
  *
  * @author Nitesh Kant
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 class RxNettyServerBackedServer extends MainClassBasedServer {
 
     private static final Logger logger = LoggerFactory.getLogger(RxNettyServerBackedServer.class);

--- a/karyon2-governator/src/main/java/netflix/karyon/ShutdownModule.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/ShutdownModule.java
@@ -20,7 +20,9 @@ import javax.annotation.PostConstruct;
  * either before or after the container shutdown.
  *
  * @author Tomasz Bak
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
  */
+@Deprecated
 public class ShutdownModule extends AbstractModule {
 
     public static final int DEFAULT_PORT = 7002;

--- a/karyon2-governator/src/main/java/netflix/karyon/ShutdownModule.java
+++ b/karyon2-governator/src/main/java/netflix/karyon/ShutdownModule.java
@@ -20,7 +20,7 @@ import javax.annotation.PostConstruct;
  * either before or after the container shutdown.
  *
  * @author Tomasz Bak
- * @deprecated 2016-07-20 Karyon2 no longer supported.  Use governator or other DI framework directly
+ * @deprecated 2016-07-20 Karyon2 no longer supported.  See https://github.com/Netflix/karyon/issues/347 for more info
  */
 @Deprecated
 public class ShutdownModule extends AbstractModule {


### PR DESCRIPTION
Karyon2 is no longer a supported project.  We recommend users either use RxNetty (https://github.com/ReactiveX/RxNetty) directly in combination with Governator (https://github.com/Netflix/governator) or other DI frameworks.