### PR TITLE
Properties to configure jersey under admin resources 

### DIFF
--- a/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
@@ -2,9 +2,11 @@ package netflix.admin;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Map.Entry;
+import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -103,14 +105,12 @@ public class AdminConfigImpl implements AdminContainerConfig {
 
     @Override
     public Map<String, String> getJerseyConfigProperties() {
-        return ConfigurationUtils.getProperties(ConfigurationManager.getConfigInstance().subset(ADMIN_JERSEY_PROPERTY_PREFIX))
-                .entrySet()
-                .stream()
-                .peek(entry -> logger.info("Using admin jersey config: " + entry))
-                .collect(Collectors.toMap(
-                    entry -> JERSEY_PROPERTY_PREFIX + "." + entry.getKey().toString(),
-                    entry -> entry.getValue().toString()
-                    ));
+        Map<String, String> result = new HashMap<>();
+        Properties props = ConfigurationUtils.getProperties(ConfigurationManager.getConfigInstance().subset(ADMIN_JERSEY_PROPERTY_PREFIX));
+        for (Entry<Object, Object> prop : props.entrySet()) {
+            result.put(JERSEY_PROPERTY_PREFIX + "." + prop.getKey().toString(), prop.getValue().toString());
+        }
+        return result;
     }
     
     @Override

--- a/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminConfigImpl.java
@@ -104,8 +104,8 @@ public class AdminConfigImpl implements AdminContainerConfig {
     }
 
     @Override
-    public Map<String, String> getJerseyConfigProperties() {
-        Map<String, String> result = new HashMap<>();
+    public Map<String, Object> getJerseyConfigProperties() {
+        Map<String, Object> result = new HashMap<>();
         Properties props = ConfigurationUtils.getProperties(ConfigurationManager.getConfigInstance().subset(ADMIN_JERSEY_PROPERTY_PREFIX));
         for (Entry<Object, Object> prop : props.entrySet()) {
             result.put(JERSEY_PROPERTY_PREFIX + "." + prop.getKey().toString(), prop.getValue().toString());

--- a/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
@@ -1,9 +1,11 @@
 package netflix.admin;
 
-import com.google.inject.ImplementedBy;
+import java.util.List;
+import java.util.Map;
 
 import javax.servlet.Filter;
-import java.util.List;
+
+import com.google.inject.ImplementedBy;
 
 @ImplementedBy(AdminConfigImpl.class)
 public interface AdminContainerConfig {
@@ -16,5 +18,6 @@ public interface AdminContainerConfig {
     boolean shouldScanClassPathForPluginDiscovery();
     int listenPort();
     List<Filter> additionalFilters();
+    Map<String, String> getJerseyConfigProperties();
 
 }

--- a/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
+++ b/karyon2-admin/src/main/java/netflix/admin/AdminContainerConfig.java
@@ -18,6 +18,6 @@ public interface AdminContainerConfig {
     boolean shouldScanClassPathForPluginDiscovery();
     int listenPort();
     List<Filter> additionalFilters();
-    Map<String, String> getJerseyConfigProperties();
+    Map<String, Object> getJerseyConfigProperties();
 
 }

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -16,14 +16,18 @@
 
 package netflix.adminresources;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Inject;
-import com.google.inject.Injector;
-import com.google.inject.Module;
-import com.google.inject.Singleton;
-import com.google.inject.Stage;
-import com.netflix.governator.guice.LifecycleInjector;
-import com.netflix.governator.lifecycle.LifecycleManager;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.servlet.Filter;
 
 import org.mortbay.jetty.Connector;
 import org.mortbay.jetty.Handler;
@@ -40,15 +44,15 @@ import org.mortbay.thread.QueuedThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.servlet.Filter;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Singleton;
+import com.google.inject.Stage;
+import com.netflix.governator.guice.LifecycleInjector;
+import com.netflix.governator.lifecycle.LifecycleManager;
+import com.sun.jersey.api.core.PackagesResourceConfig;
 
 import netflix.admin.AdminConfigImpl;
 import netflix.admin.AdminContainerConfig;
@@ -139,7 +143,11 @@ public class AdminResourcesContainer {
 
                 // admin page template resources
                 AdminResourcesFilter arfTemplatesResources = adminResourceInjector.getInstance(AdminResourcesFilter.class);
-                arfTemplatesResources.setPackages(adminContainerConfig.jerseyViewableResourcePkgList());
+                Map<String, Object> props = new HashMap<>(adminContainerConfig.getJerseyConfigProperties());
+                props.compute(
+                        PackagesResourceConfig.PROPERTY_PACKAGES, 
+                        (key, current) -> adminContainerConfig.jerseyViewableResourcePkgList() + ";" + Objects.toString(current, ""));
+                arfTemplatesResources.setProperties(props);
 
                 logger.info("Admin templates context : {}", adminContainerConfig.templateResourceContext());
                 final Context adminTemplatesResHandler = new Context();
@@ -152,9 +160,12 @@ public class AdminResourcesContainer {
                 adminTemplatesResHandler.addServlet(new ServletHolder(new DefaultServlet()), "/*");
                 
                 // admin page data resources
-                final String jerseyPkgListForAjaxResources = appendCoreJerseyPackages(adminPageRegistry.buildJerseyResourcePkgListForAdminPages());
                 AdminResourcesFilter arfDataResources = adminResourceInjector.getInstance(AdminResourcesFilter.class);
-                arfDataResources.setPackages(jerseyPkgListForAjaxResources);
+                props = new HashMap<>(adminContainerConfig.getJerseyConfigProperties());
+                props.compute(
+                        PackagesResourceConfig.PROPERTY_PACKAGES, 
+                        (key, current) -> appendCoreJerseyPackages(adminPageRegistry.buildJerseyResourcePkgListForAdminPages() + ";" + Objects.toString(current, "")));
+                arfDataResources.setProperties(props);
 
                 logger.info("Admin resources context : {}", adminContainerConfig.ajaxDataResourceContext());
                 final Context adminDataResHandler = new Context();

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesContainer.java
@@ -144,9 +144,9 @@ public class AdminResourcesContainer {
                 // admin page template resources
                 AdminResourcesFilter arfTemplatesResources = adminResourceInjector.getInstance(AdminResourcesFilter.class);
                 Map<String, Object> props = new HashMap<>(adminContainerConfig.getJerseyConfigProperties());
-                props.compute(
-                        PackagesResourceConfig.PROPERTY_PACKAGES, 
-                        (key, current) -> adminContainerConfig.jerseyViewableResourcePkgList() + ";" + Objects.toString(current, ""));
+                props.put(PackagesResourceConfig.PROPERTY_PACKAGES, 
+                        adminContainerConfig.jerseyViewableResourcePkgList() + ";" + 
+                        Objects.toString(props.get(PackagesResourceConfig.PROPERTY_PACKAGES)));
                 arfTemplatesResources.setProperties(props);
 
                 logger.info("Admin templates context : {}", adminContainerConfig.templateResourceContext());
@@ -162,9 +162,9 @@ public class AdminResourcesContainer {
                 // admin page data resources
                 AdminResourcesFilter arfDataResources = adminResourceInjector.getInstance(AdminResourcesFilter.class);
                 props = new HashMap<>(adminContainerConfig.getJerseyConfigProperties());
-                props.compute(
-                        PackagesResourceConfig.PROPERTY_PACKAGES, 
-                        (key, current) -> appendCoreJerseyPackages(adminPageRegistry.buildJerseyResourcePkgListForAdminPages() + ";" + Objects.toString(current, "")));
+                props.put(PackagesResourceConfig.PROPERTY_PACKAGES, 
+                        appendCoreJerseyPackages(adminPageRegistry.buildJerseyResourcePkgListForAdminPages()) + ";" + 
+                        Objects.toString(props.get(PackagesResourceConfig.PROPERTY_PACKAGES)));
                 arfDataResources.setProperties(props);
 
                 logger.info("Admin resources context : {}", adminContainerConfig.ajaxDataResourceContext());

--- a/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesFilter.java
+++ b/karyon2-admin/src/main/java/netflix/adminresources/AdminResourcesFilter.java
@@ -1,5 +1,13 @@
 package netflix.adminresources;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+
 import com.google.inject.Injector;
 import com.netflix.explorers.providers.FreemarkerTemplateProvider;
 import com.netflix.explorers.providers.WebApplicationExceptionMapper;
@@ -7,12 +15,6 @@ import com.sun.jersey.api.core.PackagesResourceConfig;
 import com.sun.jersey.api.core.ResourceConfig;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.sun.jersey.spi.container.servlet.WebConfig;
-
-import java.util.Map;
-import java.util.Set;
-
-import javax.inject.Inject;
-import javax.servlet.ServletException;
 
 import netflix.admin.AdminFreemarkerTemplateProvider;
 
@@ -22,29 +24,19 @@ import netflix.admin.AdminFreemarkerTemplateProvider;
  * The AdminResources app needs minimal features and this class provides those.
  */
 class AdminResourcesFilter extends GuiceContainer {
-    private volatile String packages;
+    private Map<String, Object> props = Collections.emptyMap();
 
     @Inject
     AdminResourcesFilter(Injector injector) {
         super(injector);
     }
 
-    /**
-     * Set the packages for Jersey to scan for resources
-     *
-     * @param packages packages to scan
-     */
-    void setPackages(String packages) {
-        this.packages = packages;
-    }
-
     @Override
     protected ResourceConfig getDefaultResourceConfig(Map<String, Object> props,
                                                       WebConfig webConfig) throws ServletException {
-        props.put(PackagesResourceConfig.PROPERTY_PACKAGES, packages);
-        props.put(ResourceConfig.FEATURE_DISABLE_WADL, "false");
-        
-        return new PackagesResourceConfig(props) {
+        HashMap<String, Object> mergedProps = new HashMap<>(props);
+        mergedProps.putAll(this.props);
+        return new PackagesResourceConfig(mergedProps) {
             @Override
             public Set<Class<?>> getProviderClasses() {
                 Set<Class<?>> providers = super.getProviderClasses();
@@ -55,5 +47,9 @@ class AdminResourcesFilter extends GuiceContainer {
                 return providers;
             }
         };
+    }
+
+    public void setProperties(Map<String, Object> props) {
+        this.props = new HashMap<>(props);
     }
 }


### PR DESCRIPTION
Properties will be prefixed with 'netflix.admin'.  

For example, WADL for admin resources can be turned off by setting
```
netflix.admin.com.sun.jersey.config.feature.DisableWADL=true
```